### PR TITLE
Enhance Nucleus and RateFilter

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -155,6 +155,13 @@ class Nucleus(object):
             self.el = "h"
             self.A = 3
             self.short_spec_name = "h3"
+        elif name == "a":
+            #this is a convenience, enabling the use of a commonly-used alias:
+            #    He4 --> \alpha --> "a" , e.g. c12(a,g)o16
+            self.el ="he"
+            self.A = 4
+            self.short_spec_name = "he4"
+            self.raw = "he4"
         elif name == "n":
             self.el = "n"
             self.A = 1
@@ -505,12 +512,57 @@ class Library(object):
 
 
 class RateFilter(object):
-    """RateFilter stores selection rules specifying a rate or group of
-    rates to assist searching for rates stored in a Library."""
+    """RateFilter filters out a specified rate or set of rates
+    
+    A RateFilter stores selection rules specifying a rate or group of
+    rates to assist in searching for rates stored in a Library.
+    """
 
     def __init__(self, reactants=None, products=None, exact=True,
                  reverse=None, min_reactants=None, max_reactants=None,
                  min_products=None, max_products=None):
+        """Create a new RateFilter with the given selection rules
+
+        Keyword Arguments:
+            reactants -- Description of the reactants as one of:
+                1) a list of Nucleus objects
+                2) a list of string descriptions of reactant nuclides
+                   these strings must be parsable by Nucleus
+                3) a single reactant Nucleus
+                4) a single string description of the reactant nuclide
+            products  -- Description of the products in same form as above
+            exact     -- boolean, 
+                         if True, products or reactants must match exactly [default]
+                         if False, then all products or reactants must be found
+                         in a comparison rate, but the comparison may contain
+                         additional products or reactants
+            reverse   -- boolean,
+                         if True, only match reverse rates
+                         if False, only match forward rates
+                         if None, you don't care, match both [default]
+            min_reactants -- int, match Rates that have at least this many reactants
+            min_products  -- int, match Rates that have at least this many products
+            max_reactants -- int, match Rates that have no more than this many reactants
+            max_products  -- int, match Rates that have no more than this many products
+        
+        Examples:
+            Create a filter that finds all proton capture and proton-burning reactions
+            in a Library instance my_library
+            >>> pcap_filter = RateFilter(reactants='p', exact=False)
+            >>> pcap_library = my_libarary.filter(pcap_filter)
+            or you can use Nucleus:
+            >>> pcap_filter = RateFilter(reactants=Nucleus('p'), exact=False)
+            >>> pcap_library = my_libarary.filter(pcap_filter)
+
+            Create a filter that finds C12 (a,g) O16 
+            Notes:
+                + photons/gammas are not treated as nuclides, so they cannot be
+                a reactant or product
+                + this rate is in the ReacLib library used here as 
+                O16 --> He4 C12 -- you need to know how your library treats rates
+            >>> cago_filter = RateFilter(reactants='o16', products=['c12', 'a')
+            >>> cago_library = my_libarary.filter(cago_filter)
+        """
         self.reactants = []
         self.products = []
         self.exact = exact
@@ -525,7 +577,7 @@ class RateFilter(object):
                 reactants = [reactants]
             self.reactants = [self._cast_nucleus(r) for r in reactants]
         if products:
-            if type(products) == Nucleus or type(reactants) == str:
+            if type(products) == Nucleus or type(products) == str:
                 products = [products]
             self.products = [self._cast_nucleus(r) for r in products]
 


### PR DESCRIPTION
+ I've added an alias for He4 to Nucleus that translates "a" into "He4"
+ I've added documentation/docstrings to RateFilter
+ I fixed a bug in RateFilter.__init__, replacing a mis-placed
"reactants" with "products"

I ran pytest.  There were failures, but not from my code as best I can tell.  I'm pushing to (and building off of) `development`, so this may be why there are failures.

Please do let me know if any edits/changes you would like.