### PR TITLE
Apply tabular rate fixes from MESA comparison

### DIFF
--- a/examples/urca-23_starkiller/_parameters
+++ b/examples/urca-23_starkiller/_parameters
@@ -1,7 +1,2 @@
-# Turn off heating due to the relaxation of the
-# electron fermi distribution at high densities
-# caused by electron capture reactions.
-# Turning off heating in this way is unphysical
-# but can be useful for measuring the size of
-# this heating effect.
-disable_fermi_heating          logical   .false.
+# Turn off thermal neutrino losses
+disable_thermal_neutrinos      logical   .false.

--- a/examples/urca-23_starkiller/actual_network.F90
+++ b/examples/urca-23_starkiller/actual_network.F90
@@ -69,8 +69,7 @@ module actual_network
   integer, parameter :: i_drate_dt    = 2
   integer, parameter :: i_scor        = 3
   integer, parameter :: i_dscor_dt    = 4
-  integer, parameter :: i_dqweak      = 5
-  integer, parameter :: i_epart       = 6
+  integer, parameter :: i_eneut       = 4
 
   character (len=16), save :: spec_names(nspec)
   character (len= 5), save :: short_spec_names(nspec)

--- a/pynucastro/networks/base_fortran_network.py
+++ b/pynucastro/networks/base_fortran_network.py
@@ -600,16 +600,6 @@ class BaseFortranNetwork(RateCollection):
                 self.indent*n_indent, r.table_index_name))
             of.write('{}integer               :: num_header_{}\n'.format(
                 self.indent*n_indent, r.table_index_name))
-
-            # This is used to distinguish electron capture reactions from beta decays
-            # for the purpose of setting the sign of the electron chemical potential
-            # contribution to the energy generation. Not intended for positron capture or decay.
-            if r.products[0].Z < r.reactants[0].Z:
-                invert_echemical_string = '.false.'
-            else:
-                invert_echemical_string = '.true.'
-            of.write('{}logical, parameter    :: invert_chemical_potential_{} = {}\n'.format(
-                self.indent*n_indent, r.table_index_name, invert_echemical_string))
             of.write('\n')
 
     def _declare_managed_tables(self, n_indent, of):
@@ -658,9 +648,9 @@ class BaseFortranNetwork(RateCollection):
             of.write('{}allocate(temp_table_{}(num_temp_{}))\n'.format(
                 self.indent*n_indent, r.table_index_name, r.table_index_name))
 
-            of.write('{}call init_tab_info(rate_table_{}, rhoy_table_{}, temp_table_{}, num_rhoy_{}, num_temp_{}, num_vars_{}, rate_table_file_{}, num_header_{}, invert_chemical_potential_{})\n'.format(
+            of.write('{}call init_tab_info(rate_table_{}, rhoy_table_{}, temp_table_{}, num_rhoy_{}, num_temp_{}, num_vars_{}, rate_table_file_{}, num_header_{})\n'.format(
                 self.indent*n_indent, r.table_index_name, r.table_index_name, r.table_index_name, r.table_index_name,
-                r.table_index_name, r.table_index_name, r.table_index_name, r.table_index_name, r.table_index_name))
+                r.table_index_name, r.table_index_name, r.table_index_name, r.table_index_name))
 
             of.write('\n')
 

--- a/pynucastro/templates/starkiller-microphysics/_parameters.template
+++ b/pynucastro/templates/starkiller-microphysics/_parameters.template
@@ -1,7 +1,2 @@
-# Turn off heating due to the relaxation of the
-# electron fermi distribution at high densities
-# caused by electron capture reactions.
-# Turning off heating in this way is unphysical
-# but can be useful for measuring the size of
-# this heating effect.
-disable_fermi_heating          logical   .false.
+# Turn off thermal neutrino losses
+disable_thermal_neutrinos      logical   .false.

--- a/pynucastro/templates/starkiller-microphysics/actual_network.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/actual_network.F90.template
@@ -54,8 +54,7 @@ module actual_network
   integer, parameter :: i_drate_dt    = 2
   integer, parameter :: i_scor        = 3
   integer, parameter :: i_dscor_dt    = 4
-  integer, parameter :: i_dqweak      = 5
-  integer, parameter :: i_epart       = 6
+  integer, parameter :: i_eneut       = 4
 
   character (len=16), save :: spec_names(nspec)
   character (len= 5), save :: short_spec_names(nspec)

--- a/pynucastro/templates/starkiller-microphysics/actual_rhs.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/actual_rhs.F90.template
@@ -10,9 +10,8 @@ module actual_rhs_module
   implicit none
 
   type :: rate_eval_t
-     real(rt) :: unscreened_rates(4, nrates)
+     real(rt) :: unscreened_rates(num_rate_groups, nrates)
      real(rt) :: screened_rates(nrates)
-     real(rt) :: add_energy(nrat_tabular)
      real(rt) :: add_energy_rate(nrat_tabular)
   end type rate_eval_t
   
@@ -47,7 +46,6 @@ contains
     rate_eval % unscreened_rates(i_scor, :) = ONE
     rate_eval % unscreened_rates(i_dscor_dt, :) = ZERO
     rate_eval % screened_rates = ZERO
-    rate_eval % add_energy = ZERO
     rate_eval % add_energy_rate = ZERO
 
   end subroutine zero_rate_eval
@@ -65,8 +63,7 @@ contains
     type(rate_eval_t), intent(out) :: rate_eval
     type(plasma_state) :: pstate
     real(rt) :: Y(nspec)
-    real(rt) :: raw_rates(4, nrates)
-    real(rt) :: reactvec(num_rate_groups+2)
+    real(rt) :: reactvec(num_rate_groups)
     integer :: i, j
     real(rt) :: rhoy, scor, dscor_dt, dscor_dd
 
@@ -82,7 +79,7 @@ contains
     call fill_plasma_state(pstate, state % T, state % rho, Y)
     do i = 1, nrat_reaclib
        call reaclib_evaluate(pstate, state % T, i, reactvec)
-       rate_eval % unscreened_rates(:,i) = reactvec(1:4)
+       rate_eval % unscreened_rates(:,i) = reactvec(:)
     end do
 
     ! Evaluate screening factors
@@ -103,7 +100,7 @@ contains
     
     !$acc routine seq
 
-    use extern_probin_module, only: do_constant_volume_burn
+    use extern_probin_module, only: do_constant_volume_burn, disable_thermal_neutrinos
     use burn_type_module, only: net_itemp, net_ienuc
     use sneut_module, only: sneut5
     use temperature_integration_module, only: temperature_rhs
@@ -113,7 +110,7 @@ contains
     type(burn_t) :: state
     type(rate_eval_t) :: rate_eval
     real(rt) :: Y(nspec), ydot_nuc(nspec)
-    real(rt) :: reactvec(num_rate_groups+2)
+    real(rt) :: reactvec(num_rate_groups)
     integer :: i, j
     real(rt) :: rhoy, ye, enuc
     real(rt) :: sneut, dsneutdt, dsneutdd, snuda, snudz
@@ -131,17 +128,15 @@ contains
     ! ion binding energy contributions
     call ener_gener_rate(ydot_nuc, enuc)
 
-    ! additional per-reaction energies
-    ! including Q-value modification and electron chemical potential
-    <enuc_add_energy>(2)
-
-    ! additional energy generation rates
-    ! including gamma heating and reaction neutrino losses (non-thermal)
+    ! include reaction neutrino losses (non-thermal)
     <enuc_add_energy_rate>(2)
 
-
     ! Get the thermal neutrino losses
-    call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
+    if (.not. disable_thermal_neutrinos) then
+       call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
+    else
+       sneut = ZERO
+    end if
 
     ! Append the energy equation (this is erg/g/s)
     state % ydot(net_ienuc) = enuc - sneut
@@ -178,6 +173,7 @@ contains
 
     !$acc routine seq
 
+    use extern_probin_module, only: disable_thermal_neutrinos
     use burn_type_module, only: net_itemp, net_ienuc
     use sneut_module, only: sneut5
     use temperature_integration_module, only: temperature_jac
@@ -187,7 +183,6 @@ contains
     
     type(burn_t) :: state
     type(rate_eval_t) :: rate_eval
-    real(rt) :: reactvec(num_rate_groups+2)
     real(rt) :: screened_rates_dt(nrates)
     real(rt) :: Y(nspec), yderivs(nspec)
     real(rt) :: ye, rhoy, b1, scratch
@@ -230,21 +225,25 @@ contains
     enddo
 
     ! Account for the thermal neutrino losses
-    call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
+    if (.not. disable_thermal_neutrinos) then
+       call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
-    do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
-       call get_jac_entry(state, net_ienuc, j, scratch)
-       scratch = scratch - b1
-       call set_jac_entry(state, net_ienuc, j, scratch)
-    enddo
+       do j = 1, nspec
+          b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+          call get_jac_entry(state, net_ienuc, j, scratch)
+          scratch = scratch - b1
+          call set_jac_entry(state, net_ienuc, j, scratch)
+       enddo
+    endif
 
     ! Energy generation rate Jacobian element with respect to temperature
     do k = 1, nspec
        call get_jac_entry(state, k, net_itemp, yderivs(k))
     enddo
     call ener_gener_rate(yderivs, scratch)
-    scratch = scratch - dsneutdt    
+    if (.not. disable_thermal_neutrinos) then
+       scratch = scratch - dsneutdt
+    endif
     call set_jac_entry(state, net_ienuc, net_itemp, scratch)
 
     ! Temperature Jacobian elements

--- a/pynucastro/templates/starkiller-microphysics/reaclib_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/reaclib_rates.F90.template
@@ -98,17 +98,6 @@ contains
     ! reactvec(2) = drate_dt , the Temperature derivative of rate
     ! reactvec(3) = scor     , the screening factor
     ! reactvec(4) = dscor_dt , the Temperature derivative of scor
-    ! reactvec(5) = dqweak   , the weak reaction dq-value (ergs)
-    !                          (This accounts for modification of the reaction Q
-    !                           due to the local density and temperature of the plasma.
-    !                           For Reaclib rates, this is 0.0d0.)
-    ! reactvec(6) = epart    , the particle energy generation rate (ergs/s)
-    ! NOTE: The particle energy generation rate (returned in ergs/s)
-    !       is the contribution to enuc from non-ion particles associated
-    !       with the reaction.
-    !       For example, this accounts for neutrino energy losses
-    !       in weak reactions and/or gamma heating of the plasma
-    !       from nuclear transitions in daughter nuclei.
 
     real(rt) :: rate, scor ! Rate and Screening Factor
     real(rt) :: drate_dt, dscor_dt ! Temperature derivatives

--- a/pynucastro/templates/starkiller-microphysics/reaclib_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/reaclib_rates.F90.template
@@ -93,7 +93,7 @@ contains
     real(rt), intent(in) :: temp
     integer, intent(in) :: iwhich
 
-    real(rt), intent(inout) :: reactvec(num_rate_groups+2)
+    real(rt), intent(inout) :: reactvec(num_rate_groups)
     ! reactvec(1) = rate     , the reaction rate
     ! reactvec(2) = drate_dt , the Temperature derivative of rate
     ! reactvec(3) = scor     , the screening factor
@@ -155,8 +155,6 @@ contains
     reactvec(i_drate_dt) = drate_dt
     reactvec(i_scor)     = 1.0d0
     reactvec(i_dscor_dt) = 0.0d0
-    reactvec(i_dqweak)   = 0.0d0
-    reactvec(i_epart)    = 0.0d0
 
     ! write(*,*) '----------------------------------------'
     ! write(*,*) 'IWHICH: ', iwhich
@@ -164,8 +162,6 @@ contains
     ! write(*,*) 'reactvec(i_drate_dt)', reactvec(i_drate_dt)
     ! write(*,*) 'reactvec(i_scor)', reactvec(i_scor)
     ! write(*,*) 'reactvec(i_dscor_dt)', reactvec(i_dscor_dt)
-    ! write(*,*) 'reactvec(i_dqweak)', reactvec(i_dqweak)
-    ! write(*,*) 'reactvec(i_epart)', reactvec(i_epart)
     ! write(*,*) '----------------------------------------'
 
   end subroutine reaclib_evaluate

--- a/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
@@ -283,7 +283,7 @@ contains
                               num_rhoy, num_temp, num_vars, &
                               rhoy, temp, reactvec)
 
-    use actual_network, only: num_rate_groups
+    use actual_network, only: num_rate_groups, i_rate, i_drate_dt, i_scor, i_eneut
 
     implicit none
 

--- a/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
@@ -56,11 +56,10 @@ contains
 
   subroutine init_tab_info(rate_table, rhoy_table, temp_table, &
                            num_rhoy, num_temp, num_vars, &
-                           rate_table_file, num_header, invert_chemical_potential)
+                           rate_table_file, num_header)
     integer  :: num_rhoy, num_temp, num_vars, num_header
     real(rt) :: rate_table(num_temp, num_rhoy, num_vars), rhoy_table(num_rhoy), temp_table(num_temp)
     character(len=50) :: rate_table_file
-    logical :: invert_chemical_potential
 
     real(rt), allocatable :: rate_table_scratch(:,:,:)
     integer :: i, j, k
@@ -82,13 +81,6 @@ contains
     close(11)
 
     rate_table(:,:,:) = rate_table_scratch(:,:,3:num_vars+2)
-
-    ! Set sign for chemical potential contribution to energy generation for
-    ! electron capture vs beta decays.
-    if (invert_chemical_potential) then
-       rate_table(:,:,jtab_mu) = -rate_table(:,:,jtab_mu)
-       rate_table(:,:,jtab_vs) = -rate_table(:,:,jtab_vs)
-    end if
 
     do i = 1, num_rhoy
        rhoy_table(i) = rate_table_scratch(1, i, 1)

--- a/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
@@ -292,14 +292,14 @@ contains
                               rhoy, temp, reactvec)
 
     use actual_network, only: num_rate_groups
-    use extern_probin_module, only: disable_fermi_heating
+
     implicit none
 
     integer  :: num_rhoy, num_temp, num_vars, num_header
     real(rt) :: rate_table(num_temp, num_rhoy, num_vars), rhoy_table(num_rhoy), temp_table(num_temp)
 
     real(rt), intent(in)    :: rhoy, temp
-    real(rt), intent(inout) :: reactvec(num_rate_groups+2)
+    real(rt), intent(inout) :: reactvec(num_rate_groups)
     real(rt) :: entries(num_vars+add_vars)
 
     !$gpu
@@ -310,15 +310,10 @@ contains
                      rhoy, temp, entries)
 
     ! Recast entries into reactvec
-    reactvec(1) = entries(jtab_rate)
-    reactvec(2) = entries(k_drate_dt)
-    reactvec(3) = 1.0d0
-    reactvec(4) = 0.0d0
-    reactvec(5) = entries(jtab_dq)
-    if (.not. disable_fermi_heating) then
-       reactvec(5) = reactvec(5) + entries(jtab_mu) - entries(jtab_vs)
-    end if
-    reactvec(6) = entries(jtab_gamma) - entries(jtab_nuloss)
+    reactvec(i_rate)     = entries(jtab_rate)
+    reactvec(i_drate_dt) = entries(k_drate_dt)
+    reactvec(i_scor)     = 1.0d0
+    reactvec(i_eneut)    = -entries(jtab_nuloss)
 
   end subroutine tabular_evaluate
 


### PR DESCRIPTION
This PR fixes issues in the terms applied when using weak rates from the Suzuki, et al tabulation.

With these fixes, we agree with energy generation rates from MESA.