### PR TITLE
In list_known_rates(), skip over python or jupyter notebook files.

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -20,7 +20,7 @@ def list_known_rates():
     for _, _, filenames in os.walk(lib_path):
         for f in filenames:
             # skip over files that are not rate files
-            if f.endswith(".md") or f.endswith(".dat"):
+            if f.endswith(".md") or f.endswith(".dat") or f.endswith(".py") or f.endswith(".ipynb"):
                 continue
             try:
                 lib = Library(f)


### PR DESCRIPTION
This updates pynucastro's `list_known_rates()` function in the rates module to avoid attempting to read rates from `.py` or `.ipynb` files in the rate library directories.