### PR TITLE
jitclass -> experimental.jitclass

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -42,7 +42,7 @@ Tfactor_spec = [
 ('lnT9', numba.float64)
 ]
 
-@numba.jitclass(Tfactor_spec)
+@numba.experimental.jitclass(Tfactor_spec)
 class Tfactors(object):
     """ precompute temperature factors for speed """
 


### PR DESCRIPTION
When running some examples, I was getting a warning about this. numba.jitclass was moved to numba.experimental.jitclass. See [here](https://github.com/numba/numba/tree/master/numba/experimental).