### PR TITLE
Update NETWORK_PROPERTIES format for Starkiller Microphysics

### DIFF
--- a/pynucastro/networks/starkiller_network.py
+++ b/pynucastro/networks/starkiller_network.py
@@ -162,6 +162,7 @@ class StarKillerNetwork(BaseFortranNetwork):
 
         # write out some network properties
         with open("NETWORK_PROPERTIES", "w") as of:
-            of.write("NSCREEN {}".format(self.num_screen_calls))
+            of.write("NSCREEN := {}\n".format(self.num_screen_calls))
+            of.write("NAUX := 0\n")
 
 


### PR DESCRIPTION
Chris Degrendele points out that we were writing NETWORK_PROPERTIES incorrectly for the latest version of StarKiller Microphysics.

We now do:

```
NSCREEN := [...]
NAUX := 0
```