### PR TITLE
Adding a default ReacLibLibrary(Library)

### DIFF
--- a/pynucastro/__init__.py
+++ b/pynucastro/__init__.py
@@ -132,4 +132,5 @@ from pynucastro.rates import \
     Rate, \
     RateFilter, \
     Library, \
+    ReacLibLibrary, \
     list_known_rates

--- a/pynucastro/rates/__init__.py
+++ b/pynucastro/rates/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["rate"]
 
-from .rate import Tfactors, Library, Rate, RateFilter, UnsupportedNucleus, Nucleus, list_known_rates
+from .rate import Tfactors, Library, ReacLibLibrary, Rate, RateFilter, UnsupportedNucleus, Nucleus, list_known_rates

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -793,7 +793,7 @@ class RateFilter:
 class ReacLibLibrary(Library):
 
     def __init__(self, libfile='20180319default2', rates=None, read_library=True):
-        assert(libfile == '20180319default2'  and rates == None and read_library == True), "Only the 20180319default2 default ReacLib snapshot is accepted"
+        assert libfile == '20180319default2'  and rates == None and read_library == True, "Only the 20180319default2 default ReacLib snapshot is accepted"
         Library.__init__(self, libfile=libfile, rates=rates, read_library=read_library)
 
 class Rate:

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -790,6 +790,11 @@ class RateFilter:
                                max_products=self.max_reactants)
         return newfilter
 
+class ReacLibLibrary(Library):
+
+    def __init__(self, libfile='20180319default2', rates=None, read_library=True):
+        assert(libfile == '20180319default2'  and rates == None and read_library == True), "Only the 20180319default2 default ReacLib snapshot is accepted"
+        Library.__init__(self, libfile=libfile, rates=rates, read_library=read_library)
 
 class Rate:
     """ a single Reaclib rate, which can be composed of multiple sets """


### PR DESCRIPTION
A new ReacLibLibrary(Library) class is created to read the 20180319default2 library, without making an explicit mention of it.