### PR TITLE
Use constexpr screening interface

### DIFF
--- a/pynucastro/networks/tests/_starkiller_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/actual_rhs.H
@@ -97,7 +97,15 @@ void evaluate_rates(const burn_t& state, rate_eval_t& rate_eval) {
     Real scor2, dscor2_dt, dscor2_dd;
 
 
-    screen5(pstate, 0, zion[C12-1], aion[C12-1], zion[C12-1], aion[C12-1], scor, dscor_dt, dscor_dd);
+    {
+        constexpr auto scn_fac = scrn::calculate_screen_factor(6.0_rt, 12.0_rt, 6.0_rt, 12.0_rt);
+
+
+        static_assert(scn_fac.z1 == 6.0_rt);
+
+
+        actual_screen5(pstate, scn_fac, scor, dscor_dt);
+    }
 
 
     ratraw = rate_eval.screened_rates(k_c12_c12__he4_ne20);
@@ -116,7 +124,15 @@ void evaluate_rates(const burn_t& state, rate_eval_t& rate_eval) {
     rate_eval.dscreened_rates_dT(k_c12_c12__p_na23) = ratraw * dscor_dt + dratraw_dT * scor;
 
 
-    screen5(pstate, 1, zion[He4-1], aion[He4-1], zion[C12-1], aion[C12-1], scor, dscor_dt, dscor_dd);
+    {
+        constexpr auto scn_fac = scrn::calculate_screen_factor(2.0_rt, 4.0_rt, 6.0_rt, 12.0_rt);
+
+
+        static_assert(scn_fac.z1 == 2.0_rt);
+
+
+        actual_screen5(pstate, scn_fac, scor, dscor_dt);
+    }
 
 
     ratraw = rate_eval.screened_rates(k_he4_c12__o16);


### PR DESCRIPTION
We update to use the new Microphysics interface that calculates the screening factors at compile time rather than runtime. This will allow us to ignore the cached screening factor array (because all of those factors are evaluated inline at compile time), which will ultimately simplify the networks.