### PR TITLE
Adding unit test for SpinNuclide and SpinTable

### DIFF
--- a/pynucastro/nucdata/spin_nuclide.py
+++ b/pynucastro/nucdata/spin_nuclide.py
@@ -26,6 +26,10 @@ class SpinNuclide:
 
         return rep
 
+    def __eq__(self, other):
+
+        return self.a == other.a and self.z == other.z
+
 
 class SpinTable:
     """

--- a/pynucastro/nucdata/tests/test_spin.py
+++ b/pynucastro/nucdata/tests/test_spin.py
@@ -1,0 +1,35 @@
+from pynucastro.nucdata import SpinNuclide, SpinTable
+from numpy import array
+
+
+class TestSpin:
+
+    @classmethod
+    def setup_class(cls):
+        """ this is run once for each class before any tests """
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        """ this is run once for each class before any tests """
+        pass
+
+    def setup_method(self):
+        """ this is run once for each class before any tests """
+        #Is import to remark that the spin state gs is unique.
+        #However, due to some experimental uncertainties two values
+        #are proposed.
+
+        self.spintable_gs = SpinTable(set_double_gs=False)
+        self.spintable_double_gs = SpinTable(set_double_gs=True)
+
+    def teardown_method(self):
+        """ this is run once for each class before any tests """
+        pass
+
+    def test_spin_table(self):
+
+        #assert self.spintable_gs.get_spin_nuclide('n') == SpinNuclide(a=1, z=0, spin_states=2)
+        assert self.spintable_gs.get_spin_nuclide('pd91') == SpinNuclide(a=91, z=46, spin_states=8)
+        assert self.spintable_double_gs.get_spin_nuclide('br89') == SpinNuclide(a=89, z=35, spin_states=array([4, 6]))
+        assert self.spintable_double_gs.get_spin_nuclide('pr130') == SpinNuclide(a=130, z=59, spin_states=array([13, 15]))


### PR DESCRIPTION
Adding the `test_spin.py` unit test and the `__eq__` dunder method to the `SpinNuclide` class