### PR TITLE
fix weak tables to correctly display cgs units in header

### DIFF
--- a/pynucastro/library/tabular/20f-20o_electroncapture.dat
+++ b/pynucastro/library/tabular/20f-20o_electroncapture.dat
@@ -1,8 +1,8 @@
 !20F (2+, 3+, 4+, 1+, 5+) -> 20O,  e-capture,  with screening effects
 !USDB   GT    Q(20F-20O) = -3.8135 MeV
 !Experimental data are taken into account
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.956582e-06 4.143237e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.954820e-06 4.116000e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.952096e-06 4.080752e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/20mg-20na_electroncapture.dat
+++ b/pynucastro/library/tabular/20mg-20na_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT+Fermi     Q(20Mg-20Na) = 10.7085 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 7.667610e-01 8.340293e-06 5.352311e-06
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 7.627285e-01 8.295667e-06 5.323917e-06
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 7.613248e-01 8.280018e-06 5.313997e-06

--- a/pynucastro/library/tabular/20na-20ne_electroncapture.dat
+++ b/pynucastro/library/tabular/20na-20ne_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB  GT+Fermi    Q(20Na-20Ne) = 13.8921 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 4.788916e-08 1.360251e-08 3.734737e-01 4.961709e-06 5.579834e-06
 1.000000e+07 1.584893e+07 1.952256e-06 4.764883e-08 1.360251e-08 3.685021e-01 4.894759e-06 5.504924e-06
 1.000000e+07 2.511886e+07 1.949533e-06 4.731238e-08 1.360251e-08 3.664966e-01 4.867672e-06 5.474712e-06

--- a/pynucastro/library/tabular/20ne-20f_electroncapture.dat
+++ b/pynucastro/library/tabular/20ne-20f_electroncapture.dat
@@ -3,8 +3,8 @@
 !FB (0+ -> 2+) is included
 !Experimental data are taken into account;  energies, GT stemgth
 !
-!Log(rhoY) Log(T) mu       dQ       Vs         e-cap-rate    nu-energy-loss  gamma-energy
-!                      (MeV)   (MeV)   (MeV)           (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 4.471684e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.965875e-06 4.446049e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.963151e-06 4.412404e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/21f-21o_electroncapture.dat
+++ b/pynucastro/library/tabular/21f-21o_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT    Q(21F-21O) = -8.1095 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.956582e-06 4.143237e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.954820e-06 4.116000e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.952096e-06 4.080752e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/21mg-21na_electroncapture.dat
+++ b/pynucastro/library/tabular/21mg-21na_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT+Fermi     Q(21Mg-21Na) =13.0974 MeV
 !Experimental data are usded.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 4.284597e-01 4.542148e-06 4.749647e-06
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 4.262064e-01 4.517637e-06 4.724342e-06
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 4.254123e-01 4.509219e-06 4.715539e-06

--- a/pynucastro/library/tabular/21na-21ne_electroncapture.dat
+++ b/pynucastro/library/tabular/21na-21ne_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB  GT+Fermi     Q(21Na-21Ne) = 3.5471 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 4.788916e-08 1.360251e-08 5.339493e-02 3.379647e-07 3.906711e-09
 1.000000e+07 1.584893e+07 1.952256e-06 4.764883e-08 1.360251e-08 5.265020e-02 3.329901e-07 3.841593e-09
 1.000000e+07 2.511886e+07 1.949533e-06 4.731238e-08 1.360251e-08 5.234799e-02 3.310025e-07 3.815147e-09

--- a/pynucastro/library/tabular/21ne-21f_electroncapture.dat
+++ b/pynucastro/library/tabular/21ne-21f_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT     Q(21Ne-21F) = -5.6841 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 4.471684e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.953538e-06 4.446049e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.950814e-06 4.412404e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/22mg-22na_electroncapture.dat
+++ b/pynucastro/library/tabular/22mg-22na_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT+Fermi     Q(22Mg-22Na) = 4.7816 MeV
 !Experimental data are used/
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 1.973377e-01 1.346832e-06 3.047413e-07
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 1.962682e-01 1.339203e-06 3.030689e-07
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 1.958980e-01 1.336603e-06 3.024902e-07

--- a/pynucastro/library/tabular/22na-22ne_electroncapture.dat
+++ b/pynucastro/library/tabular/22na-22ne_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT      Q(22Na-22Ne) = 2.8432 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 4.788916e-08 1.360251e-08 1.967433e-06 6.404885e-12 4.018013e-12
 1.000000e+07 1.584893e+07 1.952256e-06 4.764883e-08 1.360251e-08 1.936868e-06 6.296675e-12 3.955590e-12
 1.000000e+07 2.511886e+07 1.949533e-06 4.731238e-08 1.360251e-08 1.924864e-06 6.253329e-12 3.931075e-12

--- a/pynucastro/library/tabular/22ne-22f_electroncapture.dat
+++ b/pynucastro/library/tabular/22ne-22f_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   GT     Q(22Ne-22F) = -10.818 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 4.471684e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.953538e-06 4.446049e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.950814e-06 4.412404e-08 1.235281e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/23al-23mg_electroncapture.dat
+++ b/pynucastro/library/tabular/23al-23mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F    USDB            Q = 12.221 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     Dq       Vs       e-cap-rate    nu-energy-loss  gamma-energy
-!               (MeV)                                 (1/s)           (MeV/s)       (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 5.399347e-08 1.602180e-08 3.141738e-01 2.863461e-06 3.511085e-06
 1.000000e+07 1.584893e+07 1.965875e-06 5.367303e-08 1.602180e-08 3.140292e-01 2.862143e-06 3.509468e-06
 1.000000e+07 2.511886e+07 1.963151e-06 5.335259e-08 1.602180e-08 3.131483e-01 2.855100e-06 3.498334e-06

--- a/pynucastro/library/tabular/23mg-23na_electroncapture.dat
+++ b/pynucastro/library/tabular/23mg-23na_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F  USDB
 !Experimental data used.   Q=4.056 MeV
 !
-!Log(rhoY) Log(T) mu     Dq        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!               (MeV)                                    (1/s)        (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 5.094932e-08 1.490027e-08 6.591739e-02 4.608518e-07 1.634976e-08
 1.000000e+07 1.584893e+07 1.965875e-06 5.078911e-08 1.490027e-08 6.556922e-02 4.582277e-07 1.625217e-08
 1.000000e+07 2.511886e+07 1.963151e-06 5.046867e-08 1.490027e-08 6.543348e-02 4.573001e-07 1.621852e-08

--- a/pynucastro/library/tabular/23ne-23f_electroncapture.dat
+++ b/pynucastro/library/tabular/23ne-23f_electroncapture.dat
@@ -3,8 +3,8 @@
 !Transitions from 5/2+, 1/2+, 7/2+, 3/2+ states of 23Ne are included.  
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                 (MeV)    (MeV)     (MeV)        (1/s)          (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 4.470082e-08 1.233679e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.965875e-06 4.454060e-08 1.233679e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.963151e-06 4.405995e-08 1.233679e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/24al-24mg_electroncapture.dat
+++ b/pynucastro/library/tabular/24al-24mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F    USDB               Q=13.885 MeV
 !Experimental data are  used.
 !
-!Log(rhoY) Log(T) mu    dq        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 5.392938e-08 1.606987e-08 1.755941e-01 1.419441e-06 2.609224e-06
 1.000000e+07 1.584893e+07 1.949853e-06 5.370507e-08 1.606987e-08 1.755012e-01 1.418699e-06 2.607902e-06
 1.000000e+07 2.511886e+07 1.947129e-06 5.340066e-08 1.606987e-08 1.755618e-01 1.419225e-06 2.608743e-06

--- a/pynucastro/library/tabular/24mg-24na_electroncapture.dat
+++ b/pynucastro/library/tabular/24mg-24na_electroncapture.dat
@@ -1,8 +1,8 @@
 !24Mg (0+, 2+) -> 24Na,  e-capture,  with screening effects
 !USDB      Q=-5.5156 MeV
 !Experimental energies and FF 2+(1.369 MeV)  -> 4+(g.s.) is included 
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/24na-24ne_electroncapture.dat
+++ b/pynucastro/library/tabular/24na-24ne_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB                        Q=-2.4663 MeV
 !Experimental energies, exp. B(GT) for 1+(0.472, 1.3467MeV) -> 0+(g.s.)
 !
-!Log(rhoY) Log(T) mu       dQ       Vs         e-cap-rate    nu-energy-loss  gamma-energy
-!                       (MeV)   (MeV)   (MeV)         (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 4.788916e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.952256e-06 4.764883e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.949533e-06 4.731238e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/24si-24al_electroncapture.dat
+++ b/pynucastro/library/tabular/24si-24al_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F    USDB   Q=10.804 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 5.682932e-08 1.730354e-08 5.133576e-01 5.529442e-06 2.980240e-06
 1.000000e+07 1.584893e+07 1.948571e-06 5.660502e-08 1.730354e-08 5.139253e-01 5.535939e-06 2.981751e-06
 1.000000e+07 2.511886e+07 1.945848e-06 5.630061e-08 1.730354e-08 5.145647e-01 5.543210e-06 2.983536e-06

--- a/pynucastro/library/tabular/25al-25mg_electroncapture.dat
+++ b/pynucastro/library/tabular/25al-25mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F   USDB       Q=4.2766 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 5.392938e-08 1.606987e-08 8.329137e-02 6.139900e-07 1.492833e-08
 1.000000e+07 1.584893e+07 1.949853e-06 5.370507e-08 1.606987e-08 8.325302e-02 6.136649e-07 1.491802e-08
 1.000000e+07 2.511886e+07 1.947129e-06 5.340066e-08 1.606987e-08 8.329137e-02 6.139052e-07 1.492490e-08

--- a/pynucastro/library/tabular/25mg-25na_electroncapture.dat
+++ b/pynucastro/library/tabular/25mg-25na_electroncapture.dat
@@ -3,8 +3,8 @@
 !Transitions from 5/2+, 1/2+, 3/2+, 7/2+ and 5/2+(2nd) states of 25Mg are included.
 !Experimental data used.
 !
-!Log(rhoY) Log(T)     mu      Dq        Vs      e-cap-rate    nu-energy-loss  gamma-energy
-!                         (MeV)     (MeV)    (MeV)      (1/s)        (MeV/s)       (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 5.094932e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.580156e+07 1.965875e-06 5.072502e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.510152e+07 1.963151e-06 5.040458e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/25na-25ne_electroncapture.dat
+++ b/pynucastro/library/tabular/25na-25ne_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB      Q=-7.2981 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                  (MeV)     (MeV)     (MeV)        (1/s)           (MeV/s)          (MeV/s) 
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 4.788916e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.952304e-06 4.764883e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.949597e-06 4.731238e-08 1.360251e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/25si-25al_electroncapture.dat
+++ b/pynucastro/library/tabular/25si-25al_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F   USDB     Q=12.7427 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs          capture-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 5.682932e-08 1.730354e-08 3.487225e-01 3.726759e-06 3.632213e-06
 1.000000e+07 1.584893e+07 1.948571e-06 5.660502e-08 1.730354e-08 3.491162e-01 3.731138e-06 3.636397e-06
 1.000000e+07 2.511886e+07 1.945848e-06 5.630061e-08 1.730354e-08 3.495667e-01 3.736210e-06 3.641173e-06

--- a/pynucastro/library/tabular/26al-26mg_electroncapture.dat
+++ b/pynucastro/library/tabular/26al-26mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F     USDB   Q=4.0045 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 5.392938e-08 1.606987e-08 1.942674e-07 8.456902e-14 1.344037e-12
 1.000000e+07 1.584893e+07 1.949853e-06 5.370507e-08 1.606987e-08 1.940886e-07 8.449117e-14 1.343109e-12
 1.000000e+07 2.511886e+07 1.947129e-06 5.340066e-08 1.606987e-08 1.945808e-07 8.476397e-14 1.346205e-12

--- a/pynucastro/library/tabular/26mg-26na_electroncapture.dat
+++ b/pynucastro/library/tabular/26mg-26na_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB   Q=-9.3538 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ         Vs       e-cap-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)    (MeV)         (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/26si-26al_electroncapture.dat
+++ b/pynucastro/library/tabular/26si-26al_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F    USDB       Q = 5.0691 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 5.682932e-08 1.730354e-08 2.270597e-01 1.728408e-06 1.830755e-06
 1.000000e+07 1.584893e+07 1.948571e-06 5.660502e-08 1.730354e-08 2.273265e-01 1.730586e-06 1.831038e-06
 1.000000e+07 2.511886e+07 1.945848e-06 5.630061e-08 1.730354e-08 2.276355e-01 1.733095e-06 1.831358e-06

--- a/pynucastro/library/tabular/27al-27mg_electroncapture.dat
+++ b/pynucastro/library/tabular/27al-27mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB    Q= -2.6101 MeV
 !Experimenta data are uised.
 !
-!Log(rhoY) Log(T) mu       dQ       Vs       e-cap-rate   nu-energy-loss  gamma-energy
-!                      (MeV)    (MeV)   (MeV)       (1/s)              (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 5.392938e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.949853e-06 5.370507e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.947129e-06 5.340066e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/27mg-27na_electroncapture.dat
+++ b/pynucastro/library/tabular/27mg-27na_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB        Q=-9.0690 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T)  dQ     Vs      mu       e-cap-rate    nu-energy-loss  gamma-energy
-!                 (MeV)     (MeV)     (MeV)       (1/s)             (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 5.094932e-08 1.483619e-08 1.952897e-06 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 5.072502e-08 1.483619e-08 1.951135e-06 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 5.040458e-08 1.483619e-08 1.948411e-06 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/27p-27si_electroncapture.dat
+++ b/pynucastro/library/tabular/27p-27si_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F    USDB              Q=11.6685 MeV
 !Experimental data (energiies) are used.
 ! 
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.949212e-06 5.964916e-08 1.853722e-08 3.502918e-01 3.376302e-06 3.411861e-06
 1.000000e+07 1.584893e+07 1.947290e-06 5.944088e-08 1.853722e-08 3.507600e-01 3.381048e-06 3.416499e-06
 1.000000e+07 2.511886e+07 1.944726e-06 5.913646e-08 1.853722e-08 3.513177e-01 3.386736e-06 3.422010e-06

--- a/pynucastro/library/tabular/27si-27al_electroncapture.dat
+++ b/pynucastro/library/tabular/27si-27al_electroncapture.dat
@@ -2,8 +2,8 @@
 !GT+F   USDB              Q=4.8124 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 5.682932e-08 1.730354e-08 9.362676e-02 7.515732e-07 3.506802e-08
 1.000000e+07 1.584893e+07 1.948571e-06 5.660502e-08 1.730354e-08 9.373462e-02 7.525083e-07 3.511651e-08
 1.000000e+07 2.511886e+07 1.945848e-06 5.630061e-08 1.730354e-08 9.386420e-02 7.536007e-07 3.517315e-08

--- a/pynucastro/library/tabular/28al-28mg_electroncapture.dat
+++ b/pynucastro/library/tabular/28al-28mg_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB     Q=-1.8318 MeV
 !Experimental energies, B(GT)
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                     (MeV)    (MeV)   (MeV)         (1/s)             (MeV/s)       (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 5.392938e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.949853e-06 5.370507e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.947129e-06 5.340066e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/28mg-28na_electroncapture.dat
+++ b/pynucastro/library/tabular/28mg-28na_electroncapture.dat
@@ -1,8 +1,8 @@
 !28Mg (0+, 2+) -> 28Na,  e-capture,  with screening effects
 !USDB   Q=-14.030 MeV
 !Exp. energies, B(GT)
-!Log(rhoY) Log(T) mu     dQ       Vs         e-cap-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)   (MeV)        (1/s)              (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 5.094932e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.951135e-06 5.072502e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.948411e-06 5.040458e-08 1.483619e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/28p-28si_electroncapture.dat
+++ b/pynucastro/library/tabular/28p-28si_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB    GT+F                Q=14.3437 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)   (MeV)          (1/s)            (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.949212e-06 5.964916e-08 1.853722e-08 2.600100e-01 2.818132e-06 3.334504e-06
 1.000000e+07 1.584893e+07 1.947290e-06 5.944088e-08 1.853722e-08 2.603514e-01 2.821963e-06 3.338961e-06
 1.000000e+07 2.511886e+07 1.944726e-06 5.913646e-08 1.853722e-08 2.607594e-01 2.826580e-06 3.344270e-06

--- a/pynucastro/library/tabular/28s-28p_electroncapture.dat
+++ b/pynucastro/library/tabular/28s-28p_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB  GT+F              Q=11.2222 MeV
 !Experimental data (energies) are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)   (MeV)         (1/s)            (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.947930e-06 6.240491e-08 1.977090e-08 5.469152e-01 6.218008e-06 3.985486e-06
 1.000000e+07 1.584893e+07 1.946168e-06 6.219663e-08 1.977090e-08 5.474822e-01 6.224741e-06 3.989710e-06
 1.000000e+07 2.511886e+07 1.943444e-06 6.190824e-08 1.977090e-08 5.482770e-01 6.234208e-06 3.995594e-06

--- a/pynucastro/library/tabular/28si-28al_electroncapture.dat
+++ b/pynucastro/library/tabular/28si-28al_electroncapture.dat
@@ -2,8 +2,8 @@
 !USDB                 Q = -4.6423 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)   (MeV)        (1/s)              (MeV/s)       (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 5.682932e-08 1.730354e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.948571e-06 5.660502e-08 1.730354e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.945848e-06 5.630061e-08 1.730354e-08 0.000000e+00 0.000000e+00 0.000000e+00


### PR DESCRIPTION
Data was already in cgs but most tables still had MeV listed in header file