### PR TITLE
fix out of bounds issue

### DIFF
--- a/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
@@ -250,7 +250,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_lo == table_meta.ntemp-1)) {
+    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp-1)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 
@@ -274,7 +274,7 @@ get_entries(const table_t& table_meta,
         Real t_im1 = temp_table(itemp_lo-1);
         Real t_i   = temp_table(itemp_lo);
         Real t_ip1 = temp_table(itemp_hi);
-        Real t_ip2 = temp_table(itemp_lo+2);
+        Real t_ip2 = temp_table(itemp_hi+1);
 
         Real f_im1 = bl_clamp(rhoy_lo, rhoy_hi,
                               data(itemp_lo-1, irhoy_lo, jtab_rate),
@@ -292,8 +292,8 @@ get_entries(const table_t& table_meta,
                               rhoy);
 
         Real f_ip2 = bl_clamp(rhoy_lo, rhoy_hi,
-                              data(itemp_lo+2, irhoy_lo, jtab_rate ),
-                              data(itemp_lo+2, irhoy_hi, jtab_rate ),
+                              data(itemp_hi+1, irhoy_lo, jtab_rate ),
+                              data(itemp_hi+1, irhoy_hi, jtab_rate ),
                               rhoy);
 
         // Get central difference derivatives at the box corners

--- a/pynucastro/networks/tests/_starkiller_reference/table_rates.F90
+++ b/pynucastro/networks/tests/_starkiller_reference/table_rates.F90
@@ -267,7 +267,7 @@ contains
 
     ! Calculate the derivative of rate with temperature, d(rate)/d(t)
     ! (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
-    if (( itemp_lo .eq. 1 ) .or. ( itemp_lo .eq. num_temp-1 )) then
+    if (( itemp_lo .eq. 1 ) .or. ( itemp_hi .eq. num_temp-1 )) then
        ! We're at the first or last table cell (in temperature)
        ! First do bilinear interpolation in rhoy for the table at tlo and thi
        call bl_clamp(rhoy_lo, rhoy_hi, &
@@ -285,7 +285,7 @@ contains
        t_im1 = temp_table( itemp_lo-1 )
        t_i   = temp_table( itemp_lo )
        t_ip1 = temp_table( itemp_hi )
-       t_ip2 = temp_table( itemp_lo+2 )
+       t_ip2 = temp_table( itemp_hi+1 )
        call bl_clamp(rhoy_lo, rhoy_hi, &
             rate_table( itemp_lo-1, irhoy_lo, jtab_rate ), &
             rate_table( itemp_lo-1, irhoy_hi, jtab_rate ), &
@@ -299,8 +299,8 @@ contains
             rate_table( itemp_hi, irhoy_hi, jtab_rate ), &
             rhoy, f_ip1)
        call bl_clamp(rhoy_lo, rhoy_hi, &
-            rate_table( itemp_lo+2, irhoy_lo, jtab_rate ), &
-            rate_table( itemp_lo+2, irhoy_hi, jtab_rate ), &
+            rate_table( itemp_hi+1, irhoy_lo, jtab_rate ), &
+            rate_table( itemp_hi+1, irhoy_hi, jtab_rate ), &
             rhoy, f_ip2)
        ! Get central difference derivatives at the box corners
        drdt_i   = (f_ip1 - f_im1) / (t_ip1 - t_im1)

--- a/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
@@ -241,7 +241,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_lo == table_meta.ntemp-1)) {
+    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp-1)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 
@@ -265,7 +265,7 @@ get_entries(const table_t& table_meta,
         Real t_im1 = temp_table(itemp_lo-1);
         Real t_i   = temp_table(itemp_lo);
         Real t_ip1 = temp_table(itemp_hi);
-        Real t_ip2 = temp_table(itemp_lo+2);
+        Real t_ip2 = temp_table(itemp_hi+1);
 
         Real f_im1 = bl_clamp(rhoy_lo, rhoy_hi,
                               data(itemp_lo-1, irhoy_lo, jtab_rate),
@@ -283,8 +283,8 @@ get_entries(const table_t& table_meta,
                               rhoy);
 
         Real f_ip2 = bl_clamp(rhoy_lo, rhoy_hi,
-                              data(itemp_lo+2, irhoy_lo, jtab_rate ),
-                              data(itemp_lo+2, irhoy_hi, jtab_rate ),
+                              data(itemp_hi+1, irhoy_lo, jtab_rate ),
+                              data(itemp_hi+1, irhoy_hi, jtab_rate ),
                               rhoy);
 
         // Get central difference derivatives at the box corners

--- a/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
+++ b/pynucastro/templates/starkiller-microphysics/table_rates.F90.template
@@ -218,7 +218,7 @@ contains
 
     ! Calculate the derivative of rate with temperature, d(rate)/d(t)
     ! (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
-    if (( itemp_lo .eq. 1 ) .or. ( itemp_lo .eq. num_temp-1 )) then
+    if (( itemp_lo .eq. 1 ) .or. ( itemp_hi .eq. num_temp-1 )) then
        ! We're at the first or last table cell (in temperature)
        ! First do bilinear interpolation in rhoy for the table at tlo and thi
        call bl_clamp(rhoy_lo, rhoy_hi, &
@@ -236,7 +236,7 @@ contains
        t_im1 = temp_table( itemp_lo-1 )
        t_i   = temp_table( itemp_lo )
        t_ip1 = temp_table( itemp_hi )
-       t_ip2 = temp_table( itemp_lo+2 )
+       t_ip2 = temp_table( itemp_hi+1 )
        call bl_clamp(rhoy_lo, rhoy_hi, &
             rate_table( itemp_lo-1, irhoy_lo, jtab_rate ), &
             rate_table( itemp_lo-1, irhoy_hi, jtab_rate ), &
@@ -250,8 +250,8 @@ contains
             rate_table( itemp_hi, irhoy_hi, jtab_rate ), &
             rhoy, f_ip1)
        call bl_clamp(rhoy_lo, rhoy_hi, &
-            rate_table( itemp_lo+2, irhoy_lo, jtab_rate ), &
-            rate_table( itemp_lo+2, irhoy_hi, jtab_rate ), &
+            rate_table( itemp_hi+1, irhoy_lo, jtab_rate ), &
+            rate_table( itemp_hi+1, irhoy_hi, jtab_rate ), &
             rhoy, f_ip2)
        ! Get central difference derivatives at the box corners
        drdt_i   = (f_ip1 - f_im1) / (t_ip1 - t_im1)


### PR DESCRIPTION
Fixes issue #154 . 

Appears there was a typo of mixing up `itemp_lo` for `itemp_hi` when checking if at top of the table. 

Also changed `itemp_lo+2` to `itemp_hi+1` as I think that is clearer than the previous format.