### PR TITLE
Allow the library code to run without numba

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ setup(name='pynucastro',
                                    
                                    "nucdata/AtomicMassEvaluation/*", "nucdata/PartitionFunction/*"]},
 
-      install_requires=['networkx', 'numpy', 'numba',
-                        'sympy', 'scipy', 'matplotlib',
-                        'ipywidgets', 'numba'],
+      install_requires=['networkx', 'numpy', 'sympy',
+                        'scipy', 'matplotlib', 'ipywidgets'],
+      extras_require={"numba": ["numba"]},
       use_scm_version={"version_scheme": "post-release",
                        "write_to": "pynucastro/_version.py"},
       setup_requires=["setuptools_scm"],


### PR DESCRIPTION
Make numba an optional dependency, under the "numba" extra. The generated python network code still needs numba.

Closes #292.