### PR TITLE
implement minimum temperature to get reasonable rates

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -173,7 +173,6 @@ class SingleSet:
                                  self.a[5]*tf.T953 +
                                  self.a[6]*tf.lnT9)
 
-
     def set_string(self, prefix="set", plus_equal=False):
         """
         return a string containing the python code for this set
@@ -926,28 +925,26 @@ class Rate:
             if (check_T_min and T < 1.0e8):
 
                 T_min = minimize(self._find_rate, 1.0e7, method="Nelder-Mead", tol=1.0e5).x[0]
-
                 assert T > T_min, f"T must be greater than {T_min} K to get reasonable rates"
-                
+
             r = self._find_rate(T)
-                
+
         return r
     
     def _find_rate(self, T):
         """ A helper function to find minimum temperature required to get reasonable rates
         and evaluate appropriate rates for each set"""
-        
+
         r = 0.0
         tf = Tfactors(T)
-        
+
         for s in self.sets:
-            
+
             f = s.f()
             r += f(tf)
-        
+
         return r
-    
-    
+
     def get_nu_loss(self, T, rhoY):
         """ get the neutrino loss rate for the reaction if tabulated"""
 

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -179,13 +179,12 @@ class SingleSet:
         """
         def func(T):
             return self.f()(Tfactors(T))
-        #func = lambda T: self.f()(Tfactors(T))
 
         guess = 1.0e7
         T_min = minimize(func, guess, method="Nelder-Mead", tol=1.0e5)
 
         return T_min.x[0]
-        
+
     def set_string(self, prefix="set", plus_equal=False):
         """
         return a string containing the python code for this set
@@ -936,7 +935,7 @@ class Rate:
         else:
             tf = Tfactors(T)
             r = 0.0
-            
+
             for s in self.sets:
 
                 if check_T_min:

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -178,7 +178,7 @@ class SingleSet:
         returns the minimum temperature needed to find reasonable rates.
         """
         def func(T):
-            return self.f())(Tfactors(T))
+            return self.f()(Tfactors(T))
         #func = lambda T: self.f()(Tfactors(T))
 
         guess = 1.0e7

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -930,7 +930,7 @@ class Rate:
             r = self._find_rate(T)
 
         return r
-    
+
     def _find_rate(self, T):
         """ A helper function to find minimum temperature required to get reasonable rates
         and evaluate appropriate rates for each set"""

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -177,7 +177,10 @@ class SingleSet:
         """
         returns the minimum temperature needed to find reasonable rates.
         """
-        func = lambda T: self.f()(Tfactors(T))
+        def func(T):
+            return self.f())(Tfactors(T))
+        #func = lambda T: self.f()(Tfactors(T))
+
         guess = 1.0e7
         T_min = minimize(func, guess, method="Nelder-Mead", tol=1.0e5)
 
@@ -1165,7 +1168,7 @@ class ApproximateRate(Rate):
         pass
 
     def eval(self, T):
-        """egvaluate the approximate rate"""
+        """evaluate the approximate rate"""
 
         if self.approx_type == "ap_pg":
             if not self.is_reverse:


### PR DESCRIPTION
This pr addresses issue #229.

Give an option to check whether the input temperature of `SingleSet.eval(T)` is smaller than the minimum temperature for a given reaction to have a reasonable rate, i.e. when rate increases as T goes smaller.  