### PR TITLE
Remove old screening hook

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -52,7 +52,6 @@ class BaseCxxNetwork(ABC, RateCollection):
         self.ftags['<nrat_tabular>'] = self._nrat_tabular
         self.ftags['<nrxn>'] = self._nrxn
         self.ftags['<ebind>'] = self._ebind
-        self.ftags['<screen_add>'] = self._screen_add
         self.ftags['<compute_screening_factors>'] = self._compute_screening_factors
         self.ftags['<write_reaclib_metadata>'] = self._write_reaclib_metadata
         self.ftags['<table_num>'] = self._table_num
@@ -278,19 +277,6 @@ class BaseCxxNetwork(ABC, RateCollection):
     def _ebind(self, n_indent, of):
         for nuc in self.unique_nuclei:
             of.write(f'{self.indent*n_indent}ebind_per_nucleon({nuc.cindex()}) = {nuc.nucbind}_rt;\n')
-
-    def _screen_add(self, n_indent, of):
-        screening_map = self.get_screening_map()
-        for scr in screening_map:
-            of.write(f'{self.indent*n_indent}add_screening_factor(jscr++, ')
-            if not scr.n1.dummy:
-                of.write(f'zion[{scr.n1.cindex()}-1], aion[{scr.n1.cindex()}-1], ')
-            else:
-                of.write(f'{float(scr.n1.Z)}_rt, {float(scr.n1.A)}_rt, ')
-            if not scr.n2.dummy:
-                of.write(f'zion[{scr.n2.cindex()}-1], aion[{scr.n2.cindex()}-1]);\n\n')
-            else:
-                of.write(f'{float(scr.n2.Z)}_rt, {float(scr.n2.A)}_rt);\n\n')
 
     def _write_reaclib_metadata(self, n_indent, of):
         jset = 0

--- a/pynucastro/networks/tests/_starkiller_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/actual_rhs.H
@@ -385,10 +385,6 @@ void actual_rhs_init () {
 
     init_tabular();
 
-    screening_init();
-
-    net_screening_init();
-
 }
 
 

--- a/pynucastro/networks/tests/_starkiller_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/reaclib_rates.H
@@ -66,23 +66,6 @@ void init_reaclib() {
 
 }
 
-AMREX_INLINE
-void net_screening_init() {
-
-    using namespace Species;
-
-    // note: we need to set these up in the same order that we evaluate the
-    // rates in actual_rhs.H (yes, it's ugly)
-
-    int jscr = 0;
-
-    add_screening_factor(jscr++, zion[C12-1], aion[C12-1], zion[C12-1], aion[C12-1]);
-
-    add_screening_factor(jscr++, zion[He4-1], aion[He4-1], zion[C12-1], aion[C12-1]);
-
-
-}
-
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 tf_t evaluate_tfactors(const Real T)
 {

--- a/pynucastro/templates/starkiller-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/starkiller-cxx-microphysics/actual_rhs.H.template
@@ -248,10 +248,6 @@ void actual_rhs_init () {
 
     init_tabular();
 
-    screening_init();
-
-    net_screening_init();
-
 }
 
 

--- a/pynucastro/templates/starkiller-cxx-microphysics/reaclib_rates.H.template
+++ b/pynucastro/templates/starkiller-cxx-microphysics/reaclib_rates.H.template
@@ -66,20 +66,6 @@ void init_reaclib() {
 
 }
 
-AMREX_INLINE
-void net_screening_init() {
-
-    using namespace Species;
-
-    // note: we need to set these up in the same order that we evaluate the
-    // rates in actual_rhs.H (yes, it's ugly)
-
-    int jscr = 0;
-
-    <screen_add>(1)
-
-}
-
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 tf_t evaluate_tfactors(const Real T)
 {


### PR DESCRIPTION
This screening hook is no longer needed since we've switched over to the compile-time screening evaluation.