### PR TITLE
Clean up error handling

### DIFF
--- a/pynucastro/networks/python_network.py
+++ b/pynucastro/networks/python_network.py
@@ -42,11 +42,7 @@ class PythonNetwork(RateCollection):
         if outfile is None:
             of = sys.stdout
         else:
-            try:
-                of = open(outfile, "w")
-            except IOError:
-                print(f"unable to open {outfile}")
-                raise
+            of = open(outfile, "w")
 
         of.write("import numpy as np\n")
         of.write("from pynucastro.rates import Tfactors\n")

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -220,33 +220,25 @@ class RateCollection:
         if rates:
             if isinstance(rates, Rate):
                 rates = [rates]
-            try:
-                for r in rates:
-                    assert isinstance(r, Rate)
-            except AssertionError:
-                print('Expected Rate object or list of Rate objects passed as the rates argument.')
-                raise
+            for r in rates:
+                if not isinstance(r, Rate):
+                    raise ValueError('Expected Rate object or list of Rate objects passed as the rates argument.')
+            rlib = Library(rates=rates)
+            if not self.library:
+                self.library = rlib
             else:
-                rlib = Library(rates=rates)
-                if not self.library:
-                    self.library = rlib
-                else:
-                    self.library = self.library + rlib
+                self.library = self.library + rlib
 
         if libraries:
             if isinstance(libraries, Library):
                 libraries = [libraries]
-            try:
-                for lib in libraries:
-                    assert isinstance(lib, Library)
-            except AssertionError:
-                print('Expected Library object or list of Library objects passed as the libraries argument.')
-                raise
-            else:
-                if not self.library:
-                    self.library = libraries.pop(0)
-                for lib in libraries:
-                    self.library = self.library + lib
+            for lib in libraries:
+                if not isinstance(lib, Library):
+                    raise ValueError('Expected Library object or list of Library objects passed as the libraries argument.')
+            if not self.library:
+                self.library = libraries.pop(0)
+            for lib in libraries:
+                self.library = self.library + lib
 
         if self.library:
             self.rates = self.rates + self.library.get_rates()
@@ -335,14 +327,12 @@ class RateCollection:
         for rf in self.files:
             try:
                 rflib = Library(rf)
-            except:  # noqa
-                print(f"Error reading library from file: {rf}")
-                raise
+            except Exception as ex:
+                raise Exception(f"Error reading library from file: {rf}") from ex
+            if not self.library:
+                self.library = rflib
             else:
-                if not self.library:
-                    self.library = rflib
-                else:
-                    self.library = self.library + rflib
+                self.library = self.library + rflib
 
     def get_forward_rates(self):
         """return a list of the forward (exothermic) rates"""
@@ -428,8 +418,7 @@ class RateCollection:
         try:
             return [r for r in self.rates if r.fname == rid][0]
         except IndexError:
-            print("ERROR: rate identifier does not match a rate in this network.")
-            raise
+            raise LookupError(f"rate identifier {rid!r} does not match a rate in this network.") from None
 
     def get_rate_by_nuclei(self, reactants, products):
         """given a list of reactants and products, return any matching rates"""

--- a/pynucastro/nucdata/binding_table.py
+++ b/pynucastro/nucdata/binding_table.py
@@ -39,7 +39,7 @@ class BindingTable:
             f = open(self.datfile, 'r')
         except IOError:
             print('ERROR: data file not found!')
-            exit()
+            raise
 
         # Get rid of the header
         for _ in range(self.header_length):
@@ -61,4 +61,4 @@ class BindingTable:
         try:
             return self.nuclides[f"{n}_{z}"]
         except KeyError:
-            raise NotImplementedError(f"nuclear data for Z={z} and N={n} not available")
+            raise NotImplementedError(f"nuclear data for Z={z} and N={n} not available") from None

--- a/pynucastro/nucdata/elements.py
+++ b/pynucastro/nucdata/elements.py
@@ -5,9 +5,8 @@ class Element:
         self.Z = Z
 
 
-class UnidentifiedElement(BaseException):
-    def __init__(self):
-        return
+class UnidentifiedElement(Exception):
+    pass
 
 
 class PeriodicTable:
@@ -138,7 +137,7 @@ class PeriodicTable:
         try:
             return cls.table[abbrev.lower()]
         except IndexError:
-            raise UnidentifiedElement
+            raise UnidentifiedElement(f'Could not identify element: {abbrev}') from None
 
     @classmethod
     def lookup_Z(cls, Z):

--- a/pynucastro/nucdata/partition_function.py
+++ b/pynucastro/nucdata/partition_function.py
@@ -35,7 +35,7 @@ class PartitionFunction:
     is defined.
     """
 
-    def __init__(self, nucleus=None, name=None, temperature=None, partition_function=None):
+    def __init__(self, nucleus, name, temperature, partition_function):
 
         assert isinstance(nucleus, str)
 
@@ -81,8 +81,6 @@ class PartitionFunction:
         """
 
         assert self.nucleus == other.nucleus
-        assert self.upper_temperature() < other.lower_temperature() or \
-               self.lower_temperature() > other.upper_temperature()
 
         if self.upper_temperature() < other.lower_temperature():
             lower = self
@@ -90,6 +88,8 @@ class PartitionFunction:
         else:
             lower = other
             upper = self
+        if lower.upper_temperature() >= upper.lower_temperature():
+            raise ValueError("temperature ranges cannot overlap")
 
         temperature = np.array(list(lower.temperature) +
                                list(upper.temperature))
@@ -292,7 +292,7 @@ class PartitionFunctionCollection:
             pf_hi_table = self._partition_function_tables['etfsiq_high']
             pf_hi = pf_hi_table.get_partition_function(nuc)
         else:
-            raise Exception("invalid partition function type")
+            raise ValueError("invalid partition function type")
 
         if self.use_high_temperatures:
             if pf_lo and pf_hi:

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -19,12 +19,11 @@ def list_known_rates():
                 continue
             try:
                 lib = Library(f)
-            except:  # noqa
+            except Exception:  # pylint: disable=broad-except
                 continue
-            else:
-                print(f"{f:32} : ")
-                for r in lib.get_rates():
-                    print(f"                                 : {r}")
+            print(f"{f:32} : ")
+            for r in lib.get_rates():
+                print(f"                                 : {r}")
 
 
 class Library:
@@ -43,11 +42,12 @@ class Library:
             self._rates = None
             if isinstance(rates, Rate):
                 rates = [rates]
-            assert isinstance(rates, (dict, list, set)), "ERROR: rates in Library constructor must be a Rate object, list of Rate objects, or dictionary of Rate objects keyed by Rate.get_rate_id()"
             if isinstance(rates, dict):
                 self._rates = rates
             elif isinstance(rates, (list, set)):
                 self._add_from_rate_list(rates)
+            else:
+                raise TypeError("rates in Library constructor must be a Rate object, list of Rate objects, or dictionary of Rate objects keyed by Rate.get_rate_id()")
         else:
             self._rates = {}
         self._library_source_lines = collections.deque()
@@ -86,21 +86,17 @@ class Library:
             self._rates = {}
         for r in ratelist:
             rid = r.get_rate_id()
-            assert rid not in self._rates, "ERROR: supplied a Rate object already in the Library."
+            if rid in self._rates:
+                raise ValueError(f"supplied a Rate object already in the Library: {r}")
             self._rates[rid] = r
 
     def _read_library_file(self):
         # loop through library file, read lines
-        try:
-            flib = open(self._library_file)
-        except IOError:
-            print(f'Could not open file {self._library_file}')
-            raise
-        for line in flib:
-            ls = line.rstrip('\n')
-            if ls.strip():
-                self._library_source_lines.append(ls)
-        flib.close()
+        with open(self._library_file) as flib:
+            for line in flib:
+                ls = line.rstrip('\n')
+                if ls.strip():
+                    self._library_source_lines.append(ls)
 
         # identify distinct rates from library lines
         current_chapter = None
@@ -120,13 +116,8 @@ class Library:
                     chapter = int(line)
                 except (TypeError, ValueError):
                     # we can't interpret line as a chapter so use current_chapter
-                    try:
-                        assert current_chapter
-                    except AssertionError:
-                        print(f'ERROR: malformed library file {self._library_file}, cannot identify chapter.')
-                        raise
-                    else:
-                        chapter = current_chapter
+                    assert current_chapter, f'malformed library file {self._library_file}, cannot identify chapter.'
+                    chapter = current_chapter
                 else:
                     self._library_source_lines.popleft()
             current_chapter = chapter
@@ -168,12 +159,9 @@ class Library:
         """ Add two libraries to get a library containing rates from both. """
         new_rates = self._rates
         for rid, r in other._rates.items():
-            try:
-                assert rid not in new_rates
-            except AssertionError:
+            if rid in new_rates:
                 if r != new_rates[rid]:
-                    print(f'ERROR: rate {r} defined differently in libraries {self._library_file} and {other._library_file}\n')
-                    raise
+                    raise ValueError(f'rate {r} defined differently in libraries {self._library_file} and {other._library_file}')
             else:
                 new_rates[rid] = r
         new_library = Library(libfile=f'{self._library_file} + {other._library_file}',
@@ -205,8 +193,7 @@ class Library:
             r = [q for q in self.get_rates() if q.fname == rid][0]
             return r
         except IndexError:
-            print("ERROR: rate identifier does not match a rate in this library.")
-            raise
+            raise LookupError(f"rate identifier {rid!r} does not match a rate in this library.") from None
 
     def get_nuclei(self):
         """get the list of unique nuclei"""
@@ -246,12 +233,8 @@ class Library:
             if isinstance(nuc, Nucleus):
                 nucleus_set.add(nuc)
             else:
-                try:
-                    anuc = Nucleus(nuc)
-                except:  # noqa
-                    raise
-                else:
-                    nucleus_set.add(anuc)
+                anuc = Nucleus(nuc)
+                nucleus_set.add(anuc)
 
         # Discard rates with nuclei that are not in nucleus_set
         filtered_rates = []
@@ -292,12 +275,7 @@ class Library:
         if isinstance(filter_spec, RateFilter):
             filter_specifications = [filter_spec]
         else:
-            try:
-                iter(filter_spec)
-            except TypeError:
-                raise
-            else:
-                filter_specifications = filter_spec
+            filter_specifications = list(filter_spec)
         matching_rates = {}
         for rid, r in self._rates.items():
             for f in filter_specifications:


### PR DESCRIPTION
Replace `except AssertionError` with explicit checks, add error messages
to exceptions rather than printing them, and use more specific exception
classes where applicable.