### PR TITLE
update the burn_cell CI

### DIFF
--- a/.github/workflows/cxx-network.yml
+++ b/.github/workflows/cxx-network.yml
@@ -56,23 +56,45 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get -qq -y install curl cmake jq clang g++>=9.3.0
 
-      - name: Regenerate subch_full network
+      - name: Regenerate subch_approx network
         run: |
-          cd external/Microphysics/networks/subch_full
-          python subch_full.py
+          cd external/Microphysics/networks/subch_approx
+          python subch_approx.py
 
-      - name: Compile burn_cell
+      - name: Compile burn_cell (subch_approx)
         run: |
           cd external/Microphysics/unit_test/burn_cell
-          make NETWORK_DIR=subch2 -j 4
+          make realclean
+          make NETWORK_DIR=subch_approx -j 4
 
-      - name: Run burn_cell
+      - name: Run burn_cell (subch_approx)
         run: |
           cd external/Microphysics/unit_test/burn_cell
-          ./main3d.gnu.ex inputs_subch2 > test.out
+          ./main3d.gnu.ex inputs_subch_approx > test.out
 
-      - name: Compare to stored output
+      - name: Compare to stored output (subch_approx)
         run: |
           cd external/Microphysics/unit_test/burn_cell
-          diff -I "^AMReX" -I "^reading in reaclib rates" test.out subch2_unit_test.out
+          diff -I "^AMReX" -I "^reading in reaclib rates" test.out subch_approx_unit_test.out
+
+      - name: Regenerate ECSN network
+        run: |
+          cd external/Microphysics/networks/ECSN
+          python ecsn_network_generation.py
+
+      - name: Compile burn_cell (ECSN)
+        run: |
+          cd external/Microphysics/unit_test/burn_cell
+          make realclean
+          make NETWORK_DIR=ECSN -j 4
+
+      - name: Run burn_cell (ECSN)
+        run: |
+          cd external/Microphysics/unit_test/burn_cell
+          ./main3d.gnu.ex inputs_ecsn > test.out
+
+      - name: Compare to stored output (ECSN)
+        run: |
+          cd external/Microphysics/unit_test/burn_cell
+          diff -I "^AMReX" -I "^reading in reaclib rates" test.out ecsn_unit_test.out
 


### PR DESCRIPTION
we now generate and test subch_approx and ECSN
this extends coverage to approximate rates and tabular rates