### PR TITLE
Use full paths for imports from sibling modules

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -12,8 +12,8 @@ import re
 from abc import ABC, abstractmethod
 
 import sympy
-from pynucastro.networks import RateCollection
-from pynucastro.networks import SympyRates
+from pynucastro.networks.rate_collection import RateCollection
+from pynucastro.networks.sympy_network_support import SympyRates
 
 
 class BaseCxxNetwork(ABC, RateCollection):

--- a/pynucastro/networks/python_network.py
+++ b/pynucastro/networks/python_network.py
@@ -3,7 +3,7 @@ source"""
 
 import sys
 
-from pynucastro.networks import RateCollection
+from pynucastro.networks.rate_collection import RateCollection
 from pynucastro.rates.rate import ApproximateRate
 
 

--- a/pynucastro/networks/starkiller_cxx_network.py
+++ b/pynucastro/networks/starkiller_cxx_network.py
@@ -6,7 +6,7 @@ codes"""
 import glob
 import os
 
-from pynucastro.networks import BaseCxxNetwork
+from pynucastro.networks.base_cxx_network import BaseCxxNetwork
 
 
 class StarKillerCxxNetwork(BaseCxxNetwork):

--- a/pynucastro/nucdata/__init__.py
+++ b/pynucastro/nucdata/__init__.py
@@ -8,8 +8,7 @@ particular, the binding energies)
 from .binding_nuclide import BindingNuclide
 from .binding_table import BindingTable
 from .elements import Element, UnidentifiedElement, PeriodicTable
+from .mass_nuclide import MassNuclide, MassTable
+from .nucleus import Nucleus, UnsupportedNucleus
 from .partition_function import PartitionFunction, PartitionFunctionTable, PartitionFunctionCollection
 from .spin_nuclide import SpinNuclide, SpinTable
-from .mass_nuclide import MassNuclide, MassTable
-# this needs to go last, since it uses some of the modules above:
-from .nucleus import Nucleus, UnsupportedNucleus

--- a/pynucastro/nucdata/binding_table.py
+++ b/pynucastro/nucdata/binding_table.py
@@ -5,7 +5,7 @@ Reads tabular binding energy/nucleon data file and supplies table data.
 # Common Imports
 import os
 
-from pynucastro.nucdata import BindingNuclide
+from pynucastro.nucdata.binding_nuclide import BindingNuclide
 
 
 class BindingTable:

--- a/pynucastro/nucdata/mass_nuclide.py
+++ b/pynucastro/nucdata/mass_nuclide.py
@@ -1,4 +1,4 @@
-from pynucastro.nucdata import PeriodicTable
+from pynucastro.nucdata.elements import PeriodicTable
 import os
 
 _filename = 'mass_excess2020.txt'

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -6,8 +6,12 @@ import os
 import re
 
 from scipy.constants import physical_constants
-from pynucastro.nucdata import PeriodicTable, PartitionFunctionCollection, BindingTable, SpinTable
+
+from pynucastro.nucdata.binding_table import BindingTable
+from pynucastro.nucdata.elements import PeriodicTable
 from pynucastro.nucdata.mass_nuclide import MassTable
+from pynucastro.nucdata.partition_function import PartitionFunctionCollection
+from pynucastro.nucdata.spin_nuclide import SpinTable
 
 _pynucastro_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 _pynucastro_rates_dir = os.path.join(_pynucastro_dir, 'library')

--- a/pynucastro/nucdata/spin_nuclide.py
+++ b/pynucastro/nucdata/spin_nuclide.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-from pynucastro.nucdata import PeriodicTable
+from pynucastro.nucdata.elements import PeriodicTable
 
 
 class SpinNuclide:

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -3,8 +3,7 @@ import io
 import collections
 
 from pynucastro.nucdata import Nucleus, UnsupportedNucleus
-from pynucastro.rates import Rate, _find_rate_file
-from pynucastro.rates.rate import DerivedRate
+from pynucastro.rates.rate import DerivedRate, Rate, _find_rate_file
 
 
 def list_known_rates():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ disable = [
   "invalid-name",
   "consider-using-f-string",
   "consider-using-with",
-  "cyclic-import",
   "missing-class-docstring",
   "missing-function-docstring",
   "missing-module-docstring",


### PR DESCRIPTION
This gets rid of the warnings about circular imports and avoids any
potential ImportErrors if the imports in `__init__.py` get reordered.