### PR TITLE
Move table filename out of meta data struct

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -318,9 +318,8 @@ class BaseCxxNetwork(ABC, RateCollection):
             of.write(f'{idnt}{r.table_index_name}_meta.nrhoy = {r.table_rhoy_lines};\n')
             of.write(f'{idnt}{r.table_index_name}_meta.nvars = {r.table_num_vars};\n')
             of.write(f'{idnt}{r.table_index_name}_meta.nheader = {r.table_header_lines};\n')
-            of.write(f'{idnt}{r.table_index_name}_meta.file = "{r.table_file}";\n\n')
 
-            of.write(f'{idnt}init_tab_info({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data);\n\n')
+            of.write(f'{idnt}init_tab_info({r.table_index_name}_meta, "{r.table_file}", {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data);\n\n')
 
             of.write('\n')
 

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -317,7 +317,7 @@ class BaseCxxNetwork(ABC, RateCollection):
             of.write(f'{idnt}{r.table_index_name}_meta.ntemp = {r.table_temp_lines};\n')
             of.write(f'{idnt}{r.table_index_name}_meta.nrhoy = {r.table_rhoy_lines};\n')
             of.write(f'{idnt}{r.table_index_name}_meta.nvars = {r.table_num_vars};\n')
-            of.write(f'{idnt}{r.table_index_name}_meta.nheader = {r.table_header_lines};\n')
+            of.write(f'{idnt}{r.table_index_name}_meta.nheader = {r.table_header_lines};\n\n')
 
             of.write(f'{idnt}init_tab_info({r.table_index_name}_meta, "{r.table_file}", {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data);\n\n')
 

--- a/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
@@ -40,7 +40,6 @@ struct table_t
     int nrhoy;
     int nvars;
     int nheader;
-    std::string file;
 };
 
 // we add a 7th quantity dr/dT
@@ -67,10 +66,10 @@ namespace rate_tables
 }
 
 template <typename R, typename T, typename D>
-void init_tab_info(const table_t tf, R& rhoy, T& temp, D& data) {
+void init_tab_info(const table_t tf, const std::string file, R& rhoy, T& temp, D& data) {
 
     std::ifstream table;
-    table.open(tf.file);
+    table.open(file);
 
     std::string line;
 

--- a/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates.H
@@ -66,7 +66,7 @@ namespace rate_tables
 }
 
 template <typename R, typename T, typename D>
-void init_tab_info(const table_t tf, const std::string file, R& rhoy, T& temp, D& data) {
+void init_tab_info(const table_t tf, const std::string& file, R& rhoy, T& temp, D& data) {
 
     std::ifstream table;
     table.open(file);

--- a/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates_data.cpp
+++ b/pynucastro/networks/tests/_starkiller_cxx_reference/table_rates_data.cpp
@@ -33,18 +33,16 @@ void init_tabular()
     j_na23_ne23_meta.nrhoy = 152;
     j_na23_ne23_meta.nvars = 6;
     j_na23_ne23_meta.nheader = 6;
-    j_na23_ne23_meta.file = "23Na-23Ne_electroncapture.dat";
 
-    init_tab_info(j_na23_ne23_meta, j_na23_ne23_rhoy, j_na23_ne23_temp, j_na23_ne23_data);
+    init_tab_info(j_na23_ne23_meta, "23Na-23Ne_electroncapture.dat", j_na23_ne23_rhoy, j_na23_ne23_temp, j_na23_ne23_data);
 
 
     j_ne23_na23_meta.ntemp = 39;
     j_ne23_na23_meta.nrhoy = 152;
     j_ne23_na23_meta.nvars = 6;
     j_ne23_na23_meta.nheader = 5;
-    j_ne23_na23_meta.file = "23Ne-23Na_betadecay.dat";
 
-    init_tab_info(j_ne23_na23_meta, j_ne23_na23_rhoy, j_ne23_na23_temp, j_ne23_na23_data);
+    init_tab_info(j_ne23_na23_meta, "23Ne-23Na_betadecay.dat", j_ne23_na23_rhoy, j_ne23_na23_temp, j_ne23_na23_data);
 
 
 

--- a/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
@@ -40,7 +40,6 @@ struct table_t
     int nrhoy;
     int nvars;
     int nheader;
-    std::string file;
 };
 
 // we add a 7th quantity dr/dT
@@ -58,10 +57,10 @@ namespace rate_tables
 }
 
 template <typename R, typename T, typename D>
-void init_tab_info(const table_t tf, R& rhoy, T& temp, D& data) {
+void init_tab_info(const table_t tf, const std::string file, R& rhoy, T& temp, D& data) {
 
     std::ifstream table;
-    table.open(tf.file);
+    table.open(file);
 
     std::string line;
 

--- a/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/starkiller-cxx-microphysics/table_rates.H.template
@@ -57,7 +57,7 @@ namespace rate_tables
 }
 
 template <typename R, typename T, typename D>
-void init_tab_info(const table_t tf, const std::string file, R& rhoy, T& temp, D& data) {
+void init_tab_info(const table_t tf, const std::string& file, R& rhoy, T& temp, D& data) {
 
     std::ifstream table;
     table.open(file);


### PR DESCRIPTION
Having the filename of the tabulated data in the `table_t` struct causes problems when running with gpus (see Microphsyics [issue 952](https://github.com/AMReX-Astro/Microphysics/issues/952)).

Filename is only used at the initialization of the table, so can safely be removed from `table_t`