### PR TITLE
Restructure tests to use pytest fixtures

### DIFF
--- a/pynucastro/networks/tests/conftest.py
+++ b/pynucastro/networks/tests/conftest.py
@@ -1,0 +1,7 @@
+import pynucastro as pyna
+import pytest
+
+
+@pytest.fixture(scope="package")
+def reaclib_library():
+    return pyna.ReacLibLibrary()

--- a/pynucastro/networks/tests/test_approx_screening.py
+++ b/pynucastro/networks/tests/test_approx_screening.py
@@ -2,48 +2,36 @@
 # we'll test both symmetric and "normal" screening
 
 import pynucastro as pyna
+import pytest
 
 
 class TestApproxScreening:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def mynet(self, reaclib_library):
+        return reaclib_library.linking_nuclei(["p", "he4", "mg24",
+                                               "al27", "si28", "p31", "s32"])
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-
-        rl = pyna.ReacLibLibrary()
-        mynet = rl.linking_nuclei(["p", "he4", "mg24",
-                                   "al27", "si28", "p31", "s32"])
-
+    @pytest.fixture(scope="class")
+    def pynet_symmetric(self, mynet):
         pynet_symmetric = pyna.PythonNetwork(libraries=[mynet], symmetric_screening=True)
         pynet_symmetric.make_ap_pg_approx()
         pynet_symmetric.remove_nuclei(["al27", "p31"])
-        self.pynet_symmetric = pynet_symmetric
+        return pynet_symmetric
 
+    @pytest.fixture(scope="class")
+    def pynet(self, mynet):
         pynet = pyna.PythonNetwork(libraries=[mynet])
         pynet.make_ap_pg_approx()
         pynet.remove_nuclei(["al27", "p31"])
-        self.pynet = pynet
+        return pynet
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.pynet = None
-        self.pynet_symmetric = None
-
-    def test_symmetric_screening(self):
-        screening_map = self.pynet_symmetric.get_screening_map()
+    def test_symmetric_screening(self, pynet_symmetric):
+        screening_map = pynet_symmetric.get_screening_map()
 
         # all of the reaclib rates that are 2 body (and not "n") should have
         # be in the screening map
 
-        for r in self.pynet_symmetric.reaclib_rates:
+        for r in pynet_symmetric.reaclib_rates:
             if r.reverse:
                 nucs = [q for q in r.products if q.Z != 0]
                 if len(nucs) == 1:
@@ -59,13 +47,13 @@ class TestApproxScreening:
                 r_scn = [q for q in screening_map if q.n1 in r.symmetric_screen and q.n2 in r.symmetric_screen]
                 assert len(r_scn) == 1
 
-    def test_screening(self):
-        screening_map = self.pynet.get_screening_map()
+    def test_screening(self, pynet):
+        screening_map = pynet.get_screening_map()
 
         # all of the reaclib rates that are 2 body (and not "n") should have
         # be in the screening map
 
-        for r in self.pynet.reaclib_rates:
+        for r in pynet.reaclib_rates:
             nucs = [q for q in r.reactants if q.Z != 0]
             if len(nucs) == 1:
                 continue

--- a/pynucastro/networks/tests/test_cxx_starkiller_net.py
+++ b/pynucastro/networks/tests/test_cxx_starkiller_net.py
@@ -1,24 +1,16 @@
 # unit tests for rates
-import pynucastro.networks as networks
+from pynucastro import networks
 import os
 import filecmp
+import pytest
 
 import io
 
 
 class TestStarKillerCxxNetwork:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
+    # pylint: disable=protected-access
+    @pytest.fixture(scope="class")
+    def fn(self):
         files = ["c12-c12a-ne20-cf88",
                  "c12-c12n-mg23-cf88",
                  "c12-c12p-na23-cf88",
@@ -27,12 +19,9 @@ class TestStarKillerCxxNetwork:
                  "ne23--na23-toki",
                  "n--p-wc12"]
 
-        self.fn = networks.StarKillerCxxNetwork(files)
-        self.fn.secret_code = "testing"
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.fn = None
+        fn = networks.StarKillerCxxNetwork(files)
+        fn.secret_code = "testing"
+        return fn
 
     def cromulent_ftag(self, ftag, answer, n_indent=1):
         """ check to see if function ftag returns answer """
@@ -43,22 +32,22 @@ class TestStarKillerCxxNetwork:
         output.close()
         return result
 
-    def test_nrat_reaclib(self):
+    def test_nrat_reaclib(self, fn):
         """ test the _nrat_reaclib function """
 
         answer = ('    const int NrateReaclib = 5;\n' +
                   '    const int NumReaclibSets = 6;\n')
 
-        assert self.cromulent_ftag(self.fn._nrat_reaclib, answer, n_indent=1)
+        assert self.cromulent_ftag(fn._nrat_reaclib, answer, n_indent=1)
 
-    def test_nrat_tabular(self):
+    def test_nrat_tabular(self, fn):
         """ test the _nrat_tabular function """
 
         answer = '    const int NrateTabular = 2;\n'
 
-        assert self.cromulent_ftag(self.fn._nrat_tabular, answer, n_indent=1)
+        assert self.cromulent_ftag(fn._nrat_tabular, answer, n_indent=1)
 
-    def test_nrxn(self):
+    def test_nrxn(self, fn):
         """ test the _nrxn function """
 
         answer = ('    k_c12_c12__he4_ne20 = 1,\n' +
@@ -69,9 +58,9 @@ class TestStarKillerCxxNetwork:
                   '    k_na23__ne23 = 6,\n' +
                   '    k_ne23__na23 = 7,\n' +
                   '    NumRates = k_ne23__na23\n')
-        assert self.cromulent_ftag(self.fn._nrxn, answer, n_indent=1)
+        assert self.cromulent_ftag(fn._nrxn, answer, n_indent=1)
 
-    def test_ebind(self):
+    def test_ebind(self, fn):
         """ test the _ebind function """
 
         answer = ('        ebind_per_nucleon(N) = 0.0_rt;\n' +
@@ -83,15 +72,15 @@ class TestStarKillerCxxNetwork:
                   '        ebind_per_nucleon(Ne23) = 7.955256_rt;\n' +
                   '        ebind_per_nucleon(Na23) = 8.111493000000001_rt;\n' +
                   '        ebind_per_nucleon(Mg23) = 7.901115_rt;\n')
-        assert self.cromulent_ftag(self.fn._ebind, answer, n_indent=2)
+        assert self.cromulent_ftag(fn._ebind, answer, n_indent=2)
 
-    def test_write_network(self):
+    def test_write_network(self, fn):
         """ test the write_network function"""
         test_path = "_test_cxx/"
         reference_path = "_starkiller_cxx_reference/"
         base_path = os.path.relpath(os.path.dirname(__file__))
 
-        self.fn.write_network(odir=test_path)
+        fn.write_network(odir=test_path)
 
         files = ["actual_network_data.cpp",
                  "actual_network.H",

--- a/pynucastro/networks/tests/test_networks.py
+++ b/pynucastro/networks/tests/test_networks.py
@@ -1,76 +1,55 @@
 # unit tests for networks
-import pynucastro.networks as networks
+from pynucastro import networks
 from pynucastro.nucdata import Nucleus
 
+import pytest
 from pytest import approx
 
 
 class TestComposition:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def nuclei(self):
+        return [Nucleus("h1"),
+                Nucleus("he4"),
+                Nucleus("c12"),
+                Nucleus("o16"),
+                Nucleus("n14"),
+                Nucleus("ca40")]
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
+    @pytest.fixture(scope="class")
+    def comp(self, nuclei):
+        return networks.Composition(nuclei)
 
-    def setup_method(self):
-        """ this is run before each test """
-        self.nuclei = [Nucleus("h1"),
-                       Nucleus("he4"),
-                       Nucleus("c12"),
-                       Nucleus("o16"),
-                       Nucleus("n14"),
-                       Nucleus("ca40")]
-
-        self.comp = networks.Composition(self.nuclei)
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.tf = None
-
-    def test_solar(self):
-        self.comp.set_solar_like()
+    def test_solar(self, comp):
+        comp.set_solar_like()
 
         sum = 0.0
-        for k in self.comp.X:
-            sum += self.comp.X[k]
+        for k in comp.X:
+            sum += comp.X[k]
 
         assert sum == approx(1.0)
-        assert self.comp.X[Nucleus("h1")] == approx(0.7)
+        assert comp.X[Nucleus("h1")] == approx(0.7)
 
-    def test_set_all(self):
-        val = 1.0/len(self.nuclei)
-        self.comp.set_all(1.0/len(self.nuclei))
-        for n in self.nuclei:
-            assert self.comp.X[n] == val
+    def test_set_all(self, nuclei, comp):
+        val = 1.0/len(nuclei)
+        comp.set_all(1.0/len(nuclei))
+        for n in nuclei:
+            assert comp.X[n] == val
 
-    def test_set_nuc(self):
-        n = self.nuclei[0]
-        self.comp.set_nuc(n.raw, 0.55)
-        assert self.comp.X[n] == 0.55
+    def test_set_nuc(self, nuclei, comp):
+        n = nuclei[0]
+        comp.set_nuc(n.raw, 0.55)
+        assert comp.X[n] == 0.55
 
-    def test_get_molar(self):
-        self.comp.set_solar_like(Z=0.02)
-        molar = self.comp.get_molar()
+    def test_get_molar(self, comp):
+        comp.set_solar_like(Z=0.02)
+        molar = comp.get_molar()
         assert molar[Nucleus("he4")] == approx((0.3-0.02)/4.0)
 
 
 class TestRateCollection:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
+    @pytest.fixture(scope="class")
+    def rc(self):
         files = ["c12-pg-n13-ls09",
                  "c13-pg-n14-nacr",
                  "n13--c13-wc12",
@@ -79,29 +58,22 @@ class TestRateCollection:
                  "n15-pa-c12-nacr",
                  "o14--n14-wc12",
                  "o15--n15-wc12"]
-        self.rc = networks.RateCollection(files)
+        return networks.RateCollection(files)
 
-        self.p = Nucleus("p")
-        self.he4 = Nucleus("he4")
-        self.c12 = Nucleus("c12")
-        self.c13 = Nucleus("c13")
-        self.n13 = Nucleus("n13")
-        self.n14 = Nucleus("n14")
-        self.n15 = Nucleus("n15")
-        self.o14 = Nucleus("o14")
-        self.o15 = Nucleus("o15")
+    def test_nuclei(self, rc):
+        nuc = rc.get_nuclei()
+        assert nuc == [Nucleus("p"),
+                       Nucleus("he4"),
+                       Nucleus("c12"),
+                       Nucleus("c13"),
+                       Nucleus("n13"),
+                       Nucleus("n14"),
+                       Nucleus("n15"),
+                       Nucleus("o14"),
+                       Nucleus("o15")]
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.tf = None
-
-    def test_nuclei(self):
-        nuc = self.rc.get_nuclei()
-        assert nuc == [self.p, self.he4, self.c12, self.c13,
-                       self.n13, self.n14, self.n15, self.o14, self.o15]
-
-    def test_eval(self):
-        c = networks.Composition(self.rc.unique_nuclei)
+    def test_eval(self, rc):
+        c = networks.Composition(rc.unique_nuclei)
         c.set_solar_like()
 
         rates = {"c12 + p --> n13 <ls09_reaclib__>": 4.3825344233265815e-05,
@@ -113,12 +85,12 @@ class TestRateCollection:
                  "o14 --> n14 <wc12_reaclib_weak_>": 2.0036691481625654e-06,
                  "o15 --> n15 <wc12_reaclib_weak_>": 1.0822012944765837e-06}
 
-        rv = self.rc.evaluate_rates(1.e4, 1.e8, c)
+        rv = rc.evaluate_rates(1.e4, 1.e8, c)
 
         for r in rv:
             assert rv[r] == approx(rates[r.get_rate_id()])
 
-    def test_overview(self):
+    def test_overview(self, rc):
 
         ostr = """
 p
@@ -179,4 +151,4 @@ o15
   produced by:
      N14 + p ⟶ O15 + 𝛾
 """
-        assert self.rc.network_overview().replace(" ", "").strip() == ostr.replace(" ", "").strip()
+        assert rc.network_overview().replace(" ", "").strip() == ostr.replace(" ", "").strip()

--- a/pynucastro/networks/tests/test_python_net.py
+++ b/pynucastro/networks/tests/test_python_net.py
@@ -1,47 +1,23 @@
 # unit tests for rates
-import pynucastro.networks as networks
-import pynucastro.rates as rates
+from pynucastro import rates
+import pytest
 
 
 class TestPythonNetwork:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def rate(self):
+        return rates.Rate("c13-pg-n14-nacr")
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
+    def test_ydot_string(self, rate):
+        ydot = rate.ydot_string_py()
+        assert ydot in ("rho*Y[jc13]*Y[jp]*lambda_p_c13__n14",
+                        "rho*Y[jp]*Y[jc13]*lambda_p_c13__n14")
 
-    def setup_method(self):
-        """ this is run before each test """
-        files = ["c12-pg-n13-ls09",
-                 "c13-pg-n14-nacr",
-                 "n13--c13-wc12",
-                 "n13-pg-o14-lg06",
-                 "n14-pg-o15-im05",
-                 "n15-pa-c12-nacr",
-                 "o14--n14-wc12",
-                 "o15--n15-wc12"]
-        self.pyn = networks.PythonNetwork(files)
-        self.rate = rates.Rate("c13-pg-n14-nacr")
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.pyn = None
-        self.rate = None
-
-    def test_ydot_string(self):
-        ydot = self.rate.ydot_string_py()
-        assert ydot == "rho*Y[jc13]*Y[jp]*lambda_p_c13__n14" or \
-               ydot == "rho*Y[jp]*Y[jc13]*lambda_p_c13__n14"
-
-    def test_jacobian_string(self):
-        jac = self.rate.jacobian_string_py(self.rate.reactants[0])
+    def test_jacobian_string(self, rate):
+        jac = rate.jacobian_string_py(rate.reactants[0])
         assert jac == "rho*Y[jc13]*lambda_p_c13__n14"
 
-    def test_function_string(self):
+    def test_function_string(self, rate):
 
         ostr = """
 @numba.njit()
@@ -62,4 +38,4 @@ def p_c13__n14(tf):
     return rate
 """
 
-        assert self.rate.function_string_py().strip() == ostr.strip()
+        assert rate.function_string_py().strip() == ostr.strip()

--- a/pynucastro/networks/tests/test_python_net2.py
+++ b/pynucastro/networks/tests/test_python_net2.py
@@ -1,30 +1,15 @@
 # unit tests for rates
 import pynucastro as pyna
+import pytest
 
 
 class TestPythonNetwork2:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-
-        reaclib_library = pyna.ReacLibLibrary()
+    @pytest.fixture(scope="class")
+    def pynet(self, reaclib_library):
         mylib = reaclib_library.linking_nuclei(["he4", "c12", "o16"])
-        self.pynet = pyna.PythonNetwork(libraries=[mylib], inert_nuclei=["ne20"])
+        return pyna.PythonNetwork(libraries=[mylib], inert_nuclei=["ne20"])
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.pynet = None
-
-    def test_full_ydot_string(self):
+    def test_full_ydot_string(self, pynet):
 
         dyodt = \
 """dYdt[jo16] = (
@@ -39,5 +24,5 @@ class TestPythonNetwork2:
 
 """
 
-        assert self.pynet.full_ydot_string(pyna.Nucleus("o16")) == dyodt
-        assert self.pynet.full_ydot_string(pyna.Nucleus("ne20")) == dynedt
+        assert pynet.full_ydot_string(pyna.Nucleus("o16")) == dyodt
+        assert pynet.full_ydot_string(pyna.Nucleus("ne20")) == dynedt

--- a/pynucastro/networks/tests/test_rate_collection.py
+++ b/pynucastro/networks/tests/test_rate_collection.py
@@ -1,30 +1,16 @@
 # unit tests for a rate collection
 import pynucastro as pyna
+import pytest
 
 
 class TestRateCollection:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def rc(self, reaclib_library):
+        mylib = reaclib_library.linking_nuclei(["he4", "c12", "o16"])
+        return pyna.RateCollection(libraries=[mylib])
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-        lib = pyna.ReacLibLibrary()
-        mylib = lib.linking_nuclei(["he4", "c12", "o16"])
-        self.rc = pyna.RateCollection(libraries=[mylib])
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.rc = 0
-
-    def test_get_ratesg(self):
-        rr = self.rc.get_rates()
+    def test_get_ratesg(self, rc):
+        rr = rc.get_rates()
 
         assert len(rr) == 4
         assert rr[0].fname == "o16__he4_c12"
@@ -32,21 +18,21 @@ class TestRateCollection:
         assert rr[2].fname == "he4_c12__o16"
         assert rr[3].fname == "he4_he4_he4__c12"
 
-    def test_get_rate(self):
-        r = self.rc.get_rate("he4_he4_he4__c12")
+    def test_get_rate(self, rc):
+        r = rc.get_rate("he4_he4_he4__c12")
         assert r.fname == "he4_he4_he4__c12"
 
-    def test_find_reverse(self):
-        rr = self.rc.find_reverse(self.rc.get_rate("he4_c12__o16"))
+    def test_find_reverse(self, rc):
+        rr = rc.find_reverse(rc.get_rate("he4_c12__o16"))
         assert rr.fname == "o16__he4_c12"
 
-    def test_evaluate_energy_gen(self):
+    def test_evaluate_energy_gen(self, rc):
         # define a composition
-        comp = pyna.Composition(self.rc.unique_nuclei)
+        comp = pyna.Composition(rc.unique_nuclei)
 
         comp.set_all(0.3)
         comp.normalize()
 
         rho = 1e5
         T = 1e8
-        assert self.rc.evaluate_energy_generation(rho, T, comp) == 32.24796008826701
+        assert rc.evaluate_energy_generation(rho, T, comp) == 32.24796008826701

--- a/pynucastro/networks/tests/test_screening.py
+++ b/pynucastro/networks/tests/test_screening.py
@@ -1,34 +1,20 @@
-import pynucastro.networks as networks
+from pynucastro import networks
+import pytest
 
 
 class TestScreening:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-
+    @pytest.fixture(scope="class")
+    def rc(self):
         files = ["c12-ag-o16-nac2",
                  "c12-c12a-ne20-cf88",
                  "c12-c12n-mg23-cf88",
                  "c12-c12p-na23-cf88"]
 
-        self.rc = networks.RateCollection(files)
+        return networks.RateCollection(files)
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.rc = None
+    def test_screening(self, rc):
 
-    def test_screening(self):
-
-        screening_map = self.rc.get_screening_map()
+        screening_map = rc.get_screening_map()
 
         assert len(screening_map[0].rates) == 1
         assert len(screening_map[1].rates) == 3

--- a/pynucastro/networks/tests/test_validate.py
+++ b/pynucastro/networks/tests/test_validate.py
@@ -1,7 +1,6 @@
 # unit tests for rates
-import pynucastro.rates as rates
-
 import io
+import pytest
 
 ANSWER = \
 """validation: ni56 produced in Fe52 + He4 ⟶ Ni56 + 𝛾 never consumed.
@@ -85,35 +84,17 @@ validation: missing Co55 + p ⟶ n + Ni55 as alternative to Co55 + p ⟶ Ni56 + 
 
 class TestValidate:
 
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-
-        self.reaclib_library = rates.ReacLibLibrary()
-
+    @pytest.fixture(scope="class")
+    def reduced_library(self, reaclib_library):
         all_reactants = ["n", "p",
                          "he4", "c12", "o16", "ne20", "mg24", "si28", "s32",
                          "ar36", "ca40", "ti44", "cr48", "fe52", "ni56",
                          "al27", "p31", "cl35", "k39", "sc43", "v47", "mn51", "co55",
                          "c14", "n13", "n14", "o18", "f18", "ne21", "mg23", "na23", "si27", "s31"]
 
-        self.reduced_library = self.reaclib_library.linking_nuclei(all_reactants)
+        return reaclib_library.linking_nuclei(all_reactants)
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.reaclib_library = None
-        self.reduced_library = None
-
-    def test_validate(self):
+    def test_validate(self, reduced_library, reaclib_library):
         output = io.StringIO()
-        self.reduced_library.validate(self.reaclib_library, ostream=output)
+        reduced_library.validate(reaclib_library, ostream=output)
         assert ANSWER == output.getvalue()

--- a/pynucastro/nucdata/tests/test_binding.py
+++ b/pynucastro/nucdata/tests/test_binding.py
@@ -1,43 +1,30 @@
 # unit tests for Binding Energy database taken from AME 2016.
 from pynucastro.nucdata import BindingTable
+import pytest
 
 
 class TestAME:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def bintable(self):
+        return BindingTable()
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-        self.bintable = BindingTable()
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.bintable = None
-
-    def test_get(self):
-        nuc = self.bintable.get_nuclide(n=1, z=1)
+    def test_get(self, bintable):
+        nuc = bintable.get_nuclide(n=1, z=1)
         assert nuc.z == 1
         assert nuc.n == 1
         assert nuc.nucbind == 1.112283
 
-        nuc = self.bintable.get_nuclide(n=5, z=6)
+        nuc = bintable.get_nuclide(n=5, z=6)
         assert nuc.z == 6
         assert nuc.n == 5
         assert nuc.nucbind == 6.676456
 
-        nuc = self.bintable.get_nuclide(n=17, z=23)
+        nuc = bintable.get_nuclide(n=17, z=23)
         assert nuc.z == 23
         assert nuc.n == 17
         assert nuc.nucbind == 7.317
 
-        nuc = self.bintable.get_nuclide(n=90, z=78)
+        nuc = bintable.get_nuclide(n=90, z=78)
         assert nuc.z == 78
         assert nuc.n == 90
         assert nuc.nucbind == 7.773605

--- a/pynucastro/nucdata/tests/test_mass.py
+++ b/pynucastro/nucdata/tests/test_mass.py
@@ -1,58 +1,47 @@
 from pynucastro.nucdata import MassNuclide, MassTable
+import pytest
 from pytest import approx
 
 
 class TestMass:
+    @pytest.fixture(scope="class")
+    def nuc1(self):
+        return MassNuclide(a=1, z=0, dm=8.07132)
 
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def nuc2(self):
+        return MassNuclide(a=295, z=118, dm=201.37)
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    def test_nuclide(self, nuc1, nuc2):
 
-    def setup_method(self):
-        """ this is run once for each class before any tests """
-        self.nuc1 = MassNuclide(a=1, z=0, dm=8.07132)
-        self.nuc2 = MassNuclide(a=295, z=118, dm=201.37)
+        assert nuc1.a == 1
+        assert nuc1.z == 0
+        assert nuc1.dm == approx(8.07132)
+        assert str(nuc1) == 'n'
 
-    def teardown_method(self):
-        """ this is run once for each class before any tests """
-        pass
+        assert nuc2.a == 295
+        assert nuc2.z == 118
+        assert nuc2.dm == approx(201.37)
+        assert str(nuc2) == 'og295'
 
-    def test_nuclide(self):
+    def test_mass_table(self, nuc1, nuc2):
 
-        assert self.nuc1.a == 1
-        assert self.nuc1.z == 0
-        assert self.nuc1.dm == approx(8.07132)
-        assert str(self.nuc1) == 'n'
+        _dm = MassTable()
+        n = _dm.get_mass_diff('n')
+        he4 = _dm.get_mass_diff('he4')
+        og295 = _dm.get_mass_diff('og295')
 
-        assert self.nuc2.a == 295
-        assert self.nuc2.z == 118
-        assert self.nuc2.dm == approx(201.37)
-        assert str(self.nuc2) == 'og295'
+        assert nuc1 == n
+        assert nuc2 == og295
 
-    def test_mass_table(self):
+        assert n.a == 1
+        assert n.z == 0
+        assert n.dm == approx(8.07132)
 
-        self._dm = MassTable()
-        self.n = self._dm.get_mass_diff('n')
-        self.he4 = self._dm.get_mass_diff('he4')
-        self.og295 = self._dm.get_mass_diff('og295')
+        assert he4.a == 4
+        assert he4.z == 2
+        assert he4.dm == approx(2.42492)
 
-        assert self.nuc1 == self.n
-        assert self.nuc2 == self.og295
-
-        assert self.n.a == 1
-        assert self.n.z == 0
-        assert self.n.dm == approx(8.07132)
-
-        assert self.he4.a == 4
-        assert self.he4.z == 2
-        assert self.he4.dm == approx(2.42492)
-
-        assert self.og295.a == 295
-        assert self.og295.z == 118
-        assert self.og295.dm == approx(201.37)
+        assert og295.a == 295
+        assert og295.z == 118
+        assert og295.dm == approx(201.37)

--- a/pynucastro/nucdata/tests/test_partition.py
+++ b/pynucastro/nucdata/tests/test_partition.py
@@ -55,38 +55,31 @@ class TestPartition:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
+
+        cls.pf_table_etfsiq_low = PartitionFunctionTable(dir_etfsiq_low)
+        cls.pf_table_frdm_low = PartitionFunctionTable(dir_frdm_low)
+        cls.pf_table_etfsiq_high = PartitionFunctionTable(dir_etfsiq_high)
+        cls.pf_table_frdm_high = PartitionFunctionTable(dir_frdm_high)
+
+        cls.pf_collection_frdm = PartitionFunctionCollection(use_set='frdm')
+        cls.pf_collection_etfsiq = PartitionFunctionCollection(use_set='etfsiq')
 
     @classmethod
     def teardown_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+        """ this is run once for each class after all tests """
+        del cls.pf_table_etfsiq_low
+        del cls.pf_table_frdm_low
+        del cls.pf_table_etfsiq_high
+        del cls.pf_table_frdm_high
+
+        del cls.pf_collection_frdm
+        del cls.pf_collection_etfsiq
 
     def setup_method(self):
-        """ this is run once for each class before any tests """
-
-        self.pf_table_etfsiq_low = PartitionFunctionTable(dir_etfsiq_low)
-        self.pf_table_frdm_low = PartitionFunctionTable(dir_frdm_low)
-        self.pf_table_etfsiq_high = PartitionFunctionTable(dir_etfsiq_high)
-        self.pf_table_frdm_high = PartitionFunctionTable(dir_frdm_high)
-
-        self.co46_pf_etfsiq_low = self.pf_table_etfsiq_low.get_partition_function('co46')
-        self.ne37_pf_frdm_low = self.pf_table_frdm_low.get_partition_function('ne37')
-        self.fe47_pf_etfsiq_high = self.pf_table_etfsiq_high.get_partition_function('fe47')
-        self.po188_pf_frdm_high = self.pf_table_frdm_high.get_partition_function('po188')
-
-        self.ne19_pf_frdm_low = self.pf_table_frdm_low.get_partition_function('ne19')
-        self.ne19_pf_frdm_high = self.pf_table_frdm_high.get_partition_function('ne19')
-
-        self.co60_pf_etfsiq_low = self.pf_table_etfsiq_low.get_partition_function('co60')
-        self.co60_pf_etfsiq_high = self.pf_table_etfsiq_high.get_partition_function('co60')
-
-        self.pf_collection_frdm = PartitionFunctionCollection(use_set='frdm')
-        self.pf_collection_etfsiq = PartitionFunctionCollection(use_set='etfsiq')
+        """ this is run before each test """
 
     def teardown_method(self):
-        """ this is run once for each class before any tests """
-        pass
+        """ this is run after each test """
 
     def test_pf(self):
 
@@ -95,19 +88,30 @@ class TestPartition:
 
     def test_pf_table(self):
 
-        assert all(self.co46_pf_etfsiq_low.partition_function == ANSWER_ETFSIQ_LOW)
-        assert all(self.co46_pf_etfsiq_low.temperature == TEMPERATURES_LOW)
+        co46_pf_etfsiq_low = self.pf_table_etfsiq_low.get_partition_function('co46')
+        ne37_pf_frdm_low = self.pf_table_frdm_low.get_partition_function('ne37')
+        fe47_pf_etfsiq_high = self.pf_table_etfsiq_high.get_partition_function('fe47')
+        po188_pf_frdm_high = self.pf_table_frdm_high.get_partition_function('po188')
 
-        assert all(self.ne37_pf_frdm_low.partition_function == ANSWER_FRDM_LOW)
-        assert all(self.ne37_pf_frdm_low.temperature == TEMPERATURES_LOW)
+        assert all(co46_pf_etfsiq_low.partition_function == ANSWER_ETFSIQ_LOW)
+        assert all(co46_pf_etfsiq_low.temperature == TEMPERATURES_LOW)
 
-        assert all(self.fe47_pf_etfsiq_high.partition_function == ANSWER_ETFSIQ_HIGH)
-        assert all(self.fe47_pf_etfsiq_high.temperature == TEMPERATURES_HIGH)
+        assert all(ne37_pf_frdm_low.partition_function == ANSWER_FRDM_LOW)
+        assert all(ne37_pf_frdm_low.temperature == TEMPERATURES_LOW)
 
-        assert all(self.po188_pf_frdm_high.partition_function == ANSWER_FRDM_HIGH)
-        assert all(self.po188_pf_frdm_high.temperature == TEMPERATURES_HIGH)
+        assert all(fe47_pf_etfsiq_high.partition_function == ANSWER_ETFSIQ_HIGH)
+        assert all(fe47_pf_etfsiq_high.temperature == TEMPERATURES_HIGH)
+
+        assert all(po188_pf_frdm_high.partition_function == ANSWER_FRDM_HIGH)
+        assert all(po188_pf_frdm_high.temperature == TEMPERATURES_HIGH)
 
     def test_pfsum(self):
 
-        assert self.pf_collection_etfsiq.get_partition_function('co60') == self.co60_pf_etfsiq_low + self.co60_pf_etfsiq_high
-        assert self.pf_collection_frdm.get_partition_function('ne19') == self.ne19_pf_frdm_high + self.ne19_pf_frdm_low
+        ne19_pf_frdm_low = self.pf_table_frdm_low.get_partition_function('ne19')
+        ne19_pf_frdm_high = self.pf_table_frdm_high.get_partition_function('ne19')
+
+        co60_pf_etfsiq_low = self.pf_table_etfsiq_low.get_partition_function('co60')
+        co60_pf_etfsiq_high = self.pf_table_etfsiq_high.get_partition_function('co60')
+
+        assert self.pf_collection_frdm.get_partition_function('ne19') == ne19_pf_frdm_high + ne19_pf_frdm_low
+        assert self.pf_collection_etfsiq.get_partition_function('co60') == co60_pf_etfsiq_low + co60_pf_etfsiq_high

--- a/pynucastro/rates/tests/conftest.py
+++ b/pynucastro/rates/tests/conftest.py
@@ -1,0 +1,3 @@
+# reuse fixture from networks/tests
+# pylint: disable-next=unused-import
+from pynucastro.networks.tests.conftest import reaclib_library  # noqa: F401

--- a/pynucastro/rates/tests/test_approx_rate.py
+++ b/pynucastro/rates/tests/test_approx_rate.py
@@ -1,55 +1,49 @@
 # unit tests for rates
 
 import pynucastro as pyna
+import pytest
 from pytest import approx
 
 
 class TestTfactors:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-        reaclib_library = pyna.ReacLibLibrary()
+    @pytest.fixture(scope="class")
+    def rc(self, reaclib_library):
         mylib = reaclib_library.linking_nuclei(["mg24", "al27", "si28", "he4", "p"])
-        rc = pyna.RateCollection(libraries=[mylib])
+        return pyna.RateCollection(libraries=[mylib])
 
-        self.rp = rc.get_rate("he4_mg24__si28")
-        self.rs = [rc.get_rate("he4_mg24__p_al27"), rc.get_rate("p_al27__si28")]
+    @pytest.fixture(scope="class")
+    def rp(self, rc):
+        return rc.get_rate("he4_mg24__si28")
 
-        self.rp_reverse = rc.get_rate("si28__he4_mg24")
-        self.rs_reverse = [rc.get_rate("si28__p_al27"), rc.get_rate("p_al27__he4_mg24")]
+    @pytest.fixture(scope="class")
+    def rs(self, rc):
+        return [rc.get_rate("he4_mg24__p_al27"), rc.get_rate("p_al27__si28")]
+
+    @pytest.fixture(scope="class")
+    def ar(self, rc, rp, rs):
+        rp_reverse = rc.get_rate("si28__he4_mg24")
+        rs_reverse = [rc.get_rate("si28__p_al27"), rc.get_rate("p_al27__he4_mg24")]
 
         # approximate Mg24(a,g)Si28 together with Mg24(a,p)Al27(p,g)Si28
 
-        self.ar = pyna.ApproximateRate(primary_rate=self.rp, secondary_rates=self.rs,
-                          primary_reverse=self.rp_reverse, secondary_reverse=self.rs_reverse)
+        return pyna.ApproximateRate(primary_rate=rp, secondary_rates=rs,
+                                    primary_reverse=rp_reverse, secondary_reverse=rs_reverse)
 
-    def teardown_method(self):
-        """ this is run after each test """
+    def test_label(self, ar):
+        assert ar.fname == "mg24_he4__si28__approx"
 
-    def test_label(self):
-        assert self.ar.fname == "mg24_he4__si28__approx"
-
-    def test_low_temp(self):
+    def test_low_temp(self, ar, rp, rs):
         # at low temperatures, the approximate (a,g) should be ~ (a,g) + (a,p)
 
         T = 5.e8
-        assert self.ar.eval(T) == approx(self.rp.eval(T) + self.rs[0].eval(T), 1.e-6)
+        assert ar.eval(T) == approx(rp.eval(T) + rs[0].eval(T), 1.e-6)
 
         T = 1.e9
-        assert self.ar.eval(T) == approx(self.rp.eval(T) + self.rs[0].eval(T), 0.1)
+        assert ar.eval(T) == approx(rp.eval(T) + rs[0].eval(T), 0.1)
 
-    def test_child_rates(self):
+    def test_child_rates(self, ar):
 
-        cr = self.ar.get_child_rates()
+        cr = ar.get_child_rates()
         assert cr[0].fname == "he4_mg24__si28"
         assert cr[1].fname == "he4_mg24__p_al27"
         assert cr[2].fname == "p_al27__si28"

--- a/pynucastro/rates/tests/test_ratefilter.py
+++ b/pynucastro/rates/tests/test_ratefilter.py
@@ -1,20 +1,12 @@
 # unit tests for rates
 
 import pynucastro as pyna
+import pytest
 
 
 class TestRateFilter:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
+    @pytest.fixture(scope="class")
+    def library(self):
         """ this is run before each test """
 
         files = ["c12-pg-n13-ls09",
@@ -38,34 +30,30 @@ class TestRateFilter:
         for f in files:
             rates.append(pyna.Rate(f))
 
-        self.library = pyna.Library(rates=rates)
+        return pyna.Library(rates=rates)
 
-    def teardown_method(self):
-        """ this is run after each test """
-        self.library = None
-
-    def test_inexact_filter(self):
+    def test_inexact_filter(self, library):
         filter = pyna.RateFilter(reactants=['c12'], exact=False)
-        newlib = self.library.filter(filter)
+        newlib = library.filter(filter)
 
         rates = newlib.get_rates()
 
         assert len(rates) == 1
         assert str(rates[0]) == "C12 + p ⟶ N13 + 𝛾"
 
-    def test_custom(self):
+    def test_custom(self, library):
 
         # filter out all the rates with fluorine
 
         filter = pyna.RateFilter(filter_function=lambda r: len([q for q in r.reactants + r.products if q.Z == 9]))
-        newlib = self.library.filter(filter)
+        newlib = library.filter(filter)
 
         assert len(newlib.get_rates()) == 8
 
-    def test_exact(self):
+    def test_exact(self, library):
 
         filter = pyna.RateFilter(reactants=["n15", "p"])
-        newlib = self.library.filter(filter)
+        newlib = library.filter(filter)
 
         rates = newlib.get_rates()
 

--- a/pynucastro/rates/tests/test_rates.py
+++ b/pynucastro/rates/tests/test_rates.py
@@ -2,36 +2,23 @@
 import math
 
 from pynucastro.nucdata import Nucleus
-import pynucastro.rates as rates
+from pynucastro import rates
+import pytest
 from pytest import approx
 
 
 class TestTfactors:
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def tf(self):
+        return rates.Tfactors(2.e9)
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
-
-    def setup_method(self):
-        """ this is run before each test """
-        self.tf = rates.Tfactors(2.e9)
-
-    def teardown_method(self):
-        """ this is run after each test """
-        self.tf = None
-
-    def test_tfactors(self):
-        assert self.tf.T9 == approx(2.0)
-        assert self.tf.T9i == approx(0.5)
-        assert self.tf.T913i == approx(0.5**(1./3.))
-        assert self.tf.T913 == approx(2.0**(1./3.))
-        assert self.tf.T953 == approx(2.0**(5./3.))
-        assert self.tf.lnT9 == approx(math.log(2.0))
+    def test_tfactors(self, tf):
+        assert tf.T9 == approx(2.0)
+        assert tf.T9i == approx(0.5)
+        assert tf.T913i == approx(0.5**(1./3.))
+        assert tf.T913 == approx(2.0**(1./3.))
+        assert tf.T953 == approx(2.0**(5./3.))
+        assert tf.lnT9 == approx(math.log(2.0))
 
 
 class TestRate:
@@ -206,26 +193,7 @@ class TestRate:
 
 
 class TestDerivedRate:
-
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class before any tests """
-        pass
-
-    def setup_method(self):
-        """ this is run once for each class before any tests """
-        self.reaclib_data = rates.Library('20180319default2')
-
-    def teardown_method(self):
-        """ this is run once for each class before any tests """
-        pass
-
-    def test_ar37_na_s34(self):
+    def test_ar37_na_s34(self, reaclib_library):
         """
         Here we test the inverse rate, computed by the use of detailed balance
         of a:
@@ -235,17 +203,14 @@ class TestDerivedRate:
         reaction type.
         """
 
-        specs = rates.RateFilter(reactants=['s34', 'a'], products=['ar37', 'n'])
-        specs_inv = rates.RateFilter(reactants=['ar37', 'n'], products=['s34', 'a'])
-
-        s34_an_ar37 = self.reaclib_data.filter(filter_spec=specs).get_rates()[0]
-        ar37_na_s34_reaclib = self.reaclib_data.filter(filter_spec=specs_inv).get_rates()[0]
+        s34_an_ar37 = reaclib_library.get_rate("s34 + he4 --> n + ar37 <SM93_reaclib__>")
+        ar37_na_s34_reaclib = reaclib_library.get_rate("ar37 + n --> he4 + s34 <SM93_reaclib__reverse>")
 
         ar37_na_s34_derived = rates.DerivedRate(rate=s34_an_ar37)
 
         assert ar37_na_s34_reaclib.eval(T=2.0e9) == approx(ar37_na_s34_derived.eval(T=2.0e9), rel=2.4e-5)
 
-    def test_ar35_pg_k36(self):
+    def test_ar35_pg_k36(self, reaclib_library):
         """
         Here we test the inverse rate, computed by the use of detailed balance
         of a:
@@ -255,100 +220,67 @@ class TestDerivedRate:
         reaction type.
         """
 
-        specs = rates.RateFilter(reactants=['p', 'ar35'], products=['k36'])
-        specs_inv = rates.RateFilter(reactants=['k36'], products=['p', 'ar35'])
-
-        ar35_pg_k36 = self.reaclib_data.filter(filter_spec=specs).get_rates()[0]
-        k36_gp_ar35_reaclib = self.reaclib_data.filter(filter_spec=specs_inv).get_rates()[0]
+        ar35_pg_k36 = reaclib_library.get_rate("ar35 + p --> k36 <il10_reaclib__>")
+        k36_gp_ar35_reaclib = reaclib_library.get_rate("k36 --> p + ar35 <il10_reaclib__reverse>")
 
         k36_gp_ar35_derived = rates.DerivedRate(rate=ar35_pg_k36)
 
         assert k36_gp_ar35_reaclib.eval(T=2.0e9) == approx(k36_gp_ar35_derived.eval(T=2.0e9), rel=1.7e-5)
 
-    def test_ar35_pg_k36_with_pf(self):
+    def test_ar35_pg_k36_with_pf(self, reaclib_library):
         """
         This function test the correct rate value if we take in consideration the partition
         functions on the range 1.0e9 to 100.0e9
         """
 
-        specs = rates.RateFilter(reactants=['p', 'ar35'], products=['k36'])
-        ar35_pg_k36 = self.reaclib_data.filter(filter_spec=specs).get_rates()[0]
+        ar35_pg_k36 = reaclib_library.get_rate("ar35 + p --> k36 <il10_reaclib__>")
         k36_gp_ar35_derived = rates.DerivedRate(rate=ar35_pg_k36, use_pf=True)
 
         assert k36_gp_ar35_derived.eval(T=2.0e9) == approx(4197540.737818229)
 
-    def test_ar35_pg_k36_with_A_nuc(self):
+    def test_ar35_pg_k36_with_A_nuc(self, reaclib_library):
         """
         This function test the correct rate value if we take in consideration the
         exact values of atomic nuclear weight instead of the atomic weight A_nuc = A*m_u
         """
 
-        specs = rates.RateFilter(reactants=['p', 'ar35'], products=['k36'])
-        ar35_pg_k36 = self.reaclib_data.filter(filter_spec=specs).get_rates()[0]
+        ar35_pg_k36 = reaclib_library.get_rate("ar35 + p --> k36 <il10_reaclib__>")
         k36_gp_ar35_derived = rates.DerivedRate(rate=ar35_pg_k36, use_A_nuc=True)
 
         assert k36_gp_ar35_derived.eval(T=2.0e9) == approx(5103206.8505866425)
 
 
 class TestWeakRates:
+    @pytest.fixture(scope="class")
+    def rate1(self):
+        return rates.TabularRate("o18--f18-toki")
 
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    @pytest.fixture(scope="class")
+    def rate2(self):
+        return rates.TabularRate("na22--ne22-toki")
 
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
+    def test_reactants(self, rate1, rate2):
 
-    def setup_method(self):
-        """ this is run before each test """
+        assert len(rate1.reactants) == 1 and len(rate1.products) == 1
+        assert rate1.products[0] == Nucleus("f18")
+        assert rate1.reactants[0] == Nucleus("o18")
+        assert rate1.eval(1.e10, 1.e7) == approx(3.990249e-11)
 
-        self.rate1 = rates.TabularRate("o18--f18-toki")
-        self.rate2 = rates.TabularRate("na22--ne22-toki")
-
-    def teardown_method(self):
-        """ this is run after each test """
-        pass
-
-    def test_reactants(self):
-
-        assert len(self.rate1.reactants) == 1 and len(self.rate1.products) == 1
-        assert self.rate1.products[0] == Nucleus("f18")
-        assert self.rate1.reactants[0] == Nucleus("o18")
-        assert self.rate1.eval(1.e10, 1.e7) == approx(3.990249e-11)
-
-        assert len(self.rate2.reactants) == 1 and len(self.rate2.products) == 1
-        assert self.rate2.products[0] == Nucleus("ne22")
-        assert self.rate2.reactants[0] == Nucleus("na22")
-        assert self.rate2.eval(1.e9, 1.e6) == approx(1.387075e-05)
+        assert len(rate2.reactants) == 1 and len(rate2.products) == 1
+        assert rate2.products[0] == Nucleus("ne22")
+        assert rate2.reactants[0] == Nucleus("na22")
+        assert rate2.eval(1.e9, 1.e6) == approx(1.387075e-05)
 
 
 class TestModify:
+    @pytest.fixture(scope="function")
+    def rate(self):
+        return rates.Rate("c12-c12n-mg23-cf88")
 
-    @classmethod
-    def setup_class(cls):
-        """ this is run once for each class before any tests """
-        pass
+    def test_modify(self, rate):
 
-    @classmethod
-    def teardown_class(cls):
-        """ this is run once for each class after all tests """
-        pass
+        rate.modify_products("mg24")
 
-    def setup_method(self):
-        """ this is run before each test """
-
-        self.rate = rates.Rate("c12-c12n-mg23-cf88")
-
-    def teardown_method(self):
-        """ this is run after each test """
-        pass
-
-    def test_modify(self):
-
-        self.rate.modify_products("mg24")
-
-        assert self.rate.Q == approx(13.93356)
-        assert self.rate.products == [Nucleus("mg24")]
-        assert self.rate.modified
+        assert rate.Q == approx(13.93356)
+        assert rate.products == [Nucleus("mg24")]
+        assert rate.modified


### PR DESCRIPTION
This lets us load the ReacLib library once and automatically reuse it
for all of the tests, and some similar caching on a couple of other
expensive tests.
On my machine, this cuts the python tests (excluding the notebooks) from
3 minutes to 30 seconds.