### PR TITLE
make tabular rates hashable

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -1265,6 +1265,9 @@ class TabularRate(Rate):
 
         self.get_tabular_rate()
 
+    def __hash__(self):
+        return hash(self.__repr__())
+
     def __eq__(self, other):
         """ Determine whether two Rate objects are equal.
         They are equal if they contain identical reactants and products."""


### PR DESCRIPTION
Currently `TabularRate` isn't hashable. This breaks `RateCollection.evaulate_rates()` when a tabular rate is involved. The class doesn't inherit the `__hash__` from the `Rates` class because we changed the equality method.

This PR simply adds the `__hash__` explicitly in the `TabularRate` class.