### PR TITLE
add a test of the partition function logic in python nets

### DIFF
--- a/pynucastro/__init__.py
+++ b/pynucastro/__init__.py
@@ -130,6 +130,7 @@ from pynucastro.rates import \
     Tfactors, \
     Rate, \
     ApproximateRate, \
+    DerivedRate, \
     RateFilter, \
     Library, \
     ReacLibLibrary, \

--- a/pynucastro/networks/tests/test_python_partition_functions.py
+++ b/pynucastro/networks/tests/test_python_partition_functions.py
@@ -1,0 +1,58 @@
+import pynucastro as pyna
+import os
+import pytest
+
+
+class TestPythonPartitionNetwork:
+    @pytest.fixture(scope="class")
+    def fn(self):
+
+        all_reactions = pyna.ReacLibLibrary()
+        fwd_reactions = all_reactions.derived_forward()
+
+        nuclei = ["p", "he4", "fe52", "ni56", "co55"]
+
+        fwd_rates_lib = fwd_reactions.linking_nuclei(nuclist=nuclei,
+                                                     with_reverse=False)
+
+        derived = []
+        for r in fwd_rates_lib.get_rates():
+            d = pyna.DerivedRate(rate=r, compute_Q=False, use_pf=True)
+            derived.append(d)
+
+        der_rates_lib = pyna.Library(rates=derived)
+        full_lib = fwd_rates_lib + der_rates_lib
+
+        pynet = pyna.PythonNetwork(libraries=[full_lib])
+        pynet.write_network("der_net.py")
+
+    def test_partition_rates(self, fn):
+        """test the rate evaluation with partition functions from the
+        python network"""
+
+        import der_net
+
+        T = 5.e9
+        tf = pyna.Tfactors(T)
+
+        rate_eval = der_net.RateEval()
+
+        der_net.p_co55__he4_fe52__derived(rate_eval, tf)
+        der_net.ni56__p_co55__derived(rate_eval, tf)
+
+        assert rate_eval.p_co55__he4_fe52__derived == pytest.approx(4.570999237208017, rel=1.e-10)
+
+        assert rate_eval.ni56__p_co55__derived == pytest.approx(23790871.179938074, rel=1.e-10)
+
+
+        T = 9.e9
+        tf = pyna.Tfactors(T)
+
+        rate_eval = der_net.RateEval()
+
+        der_net.p_co55__he4_fe52__derived(rate_eval, tf)
+        der_net.ni56__p_co55__derived(rate_eval, tf)
+
+        assert rate_eval.p_co55__he4_fe52__derived == pytest.approx(15485.753590182012, rel=1.e-10)
+        assert rate_eval.ni56__p_co55__derived == pytest.approx(428973340937.6744, rel=1.e-10)
+

--- a/pynucastro/networks/tests/test_python_partition_functions.py
+++ b/pynucastro/networks/tests/test_python_partition_functions.py
@@ -1,5 +1,4 @@
 import pynucastro as pyna
-import os
 import pytest
 
 
@@ -44,7 +43,6 @@ class TestPythonPartitionNetwork:
 
         assert rate_eval.ni56__p_co55__derived == pytest.approx(23790871.179938074, rel=1.e-10)
 
-
         T = 9.e9
         tf = pyna.Tfactors(T)
 
@@ -55,4 +53,3 @@ class TestPythonPartitionNetwork:
 
         assert rate_eval.p_co55__he4_fe52__derived == pytest.approx(15485.753590182012, rel=1.e-10)
         assert rate_eval.ni56__p_co55__derived == pytest.approx(428973340937.6744, rel=1.e-10)
-


### PR DESCRIPTION
this explicitly calls some rates with PF enabled to ensure that
we don't mess up their values