### PR TITLE
Nse unit test

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -831,9 +831,11 @@ class RateCollection:
             else:
                 u_c = 0.0
 
+            nse_exponent = min(500.0, (nuc.Z * u[0] + nuc.N * u[1] - u_c + nuc.nucbind * nuc.A) / k / T / Erg2MeV)
+            
             comp_NSE.X[nuc] = m_u * nuc.A_nuc * pf / rho * (2.0 * np.pi * m_u * nuc.A_nuc * k * T / h**2)**(3. / 2.) \
-            * np.exp((nuc.Z * u[0] + nuc.N * u[1] - u_c + nuc.nucbind * nuc.A) / k / T / Erg2MeV)
-
+            * np.exp(nse_exponent)
+            
         return comp_NSE
 
     def _constraint_eq(self, u, rho, T, ye, use_coulomb_corr=True):
@@ -865,6 +867,9 @@ class RateCollection:
         init_guess = np.array(init_guess)
         is_pos_old = False
         found_sol = False
+
+        # Filter out runtimewarnings from fsolve, here we check convergence by np.isclose
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
 
         # This nested loops should fine-tune the initial guess if fsolve is unable to find a solution
         while (j < 15):

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -832,10 +832,10 @@ class RateCollection:
                 u_c = 0.0
 
             nse_exponent = min(500.0, (nuc.Z * u[0] + nuc.N * u[1] - u_c + nuc.nucbind * nuc.A) / k / T / Erg2MeV)
-            
+
             comp_NSE.X[nuc] = m_u * nuc.A_nuc * pf / rho * (2.0 * np.pi * m_u * nuc.A_nuc * k * T / h**2)**(3. / 2.) \
             * np.exp(nse_exponent)
-            
+
         return comp_NSE
 
     def _constraint_eq(self, u, rho, T, ye, use_coulomb_corr=True):

--- a/pynucastro/networks/tests/test_nse.py
+++ b/pynucastro/networks/tests/test_nse.py
@@ -1,0 +1,41 @@
+import pynucastro as pyna
+import pytest
+
+
+class TestNSE:
+    @pytest.fixture(scope="class")
+    def pynet(self, reaclib_library):
+
+        lib = reaclib_library.linking_nuclei(["p","he4","fe52",
+                                              "co55","ni56"])
+        return pyna.RateCollection(libraries=lib)
+
+    def test_nse_coul(self, pynet):
+
+        rho = 1.0e7
+        T = 6.0e9
+        ye = 0.5
+
+        nse_comp = pynet.get_comp_NSE(rho, T, ye, use_coulomb_corr=True)
+        nse_Xs = list(nse_comp.X.values())
+
+        assert nse_Xs[0] == pytest.approx(0.00573778851016, rel=1.0e-10)
+        assert nse_Xs[1] == pytest.approx(0.50055406187850, rel=1.0e-10)
+        assert nse_Xs[2] == pytest.approx(0.03711671370420, rel=1.0e-10)
+        assert nse_Xs[3] == pytest.approx(0.31557836805821, rel=1.0e-10)
+        assert nse_Xs[4] == pytest.approx(0.14101306784484, rel=1.0e-10)
+
+    def test_nse_no_coul(self, pynet):
+
+        rho = 1.0e7
+        T = 6.0e9
+        ye = 0.5
+
+        nse_comp = pynet.get_comp_NSE(rho, T, ye, use_coulomb_corr=False)
+        nse_Xs = list(nse_comp.X.values())
+
+        assert nse_Xs[0] == pytest.approx(0.00558282578105, rel=1.0e-10)
+        assert nse_Xs[1] == pytest.approx(0.52648694688751, rel=1.0e-10)
+        assert nse_Xs[2] == pytest.approx(0.03543576484397, rel=1.0e-10)
+        assert nse_Xs[3] == pytest.approx(0.30705541795776, rel=1.0e-10)
+        assert nse_Xs[4] == pytest.approx(0.12543904452967, rel=1.0e-10)

--- a/pynucastro/networks/tests/test_nse.py
+++ b/pynucastro/networks/tests/test_nse.py
@@ -6,8 +6,8 @@ class TestNSE:
     @pytest.fixture(scope="class")
     def pynet(self, reaclib_library):
 
-        lib = reaclib_library.linking_nuclei(["p","he4","fe52",
-                                              "co55","ni56"])
+        lib = reaclib_library.linking_nuclei(["p", "he4", "fe52",
+                                              "co55", "ni56"])
         return pyna.RateCollection(libraries=lib)
 
     def test_nse_coul(self, pynet):


### PR DESCRIPTION
1) Add unit test for nse. 
2) Filter out runtime warnings for fsolve, since we check convergence using np.isclose. 
3) Prevent overflow in exp by setting a cap number to the exponent.