### PR TITLE
don't check coverage on intermediate files generated by other tests

### DIFF
--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -45,4 +45,4 @@ jobs:
         run: python setup.py develop --user
 
       - name: Run tests with pytest
-        run: pytest -v -s --cov=. --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb
+        run: pytest -v -s --cov=. --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb --ignore=pynucastro/networks/tests/der_net.py --ignore=examples/*.py


### PR DESCRIPTION
e.g., we should not check coverage on der_net.py produced by the network tests.
Also exclude the scripts in examples/