### PR TITLE
Fix tabular strings

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -311,9 +311,6 @@ class Rate:
         # some rates will have no nuclei particles (e.g. gamma) on the left or
         # right -- we'll try to infer those here
 
-        self.lhs_other = []
-        self.rhs_other = []
-
         self._set_rhs_properties()
         self._set_screening()
         self._set_print_representation()
@@ -379,6 +376,9 @@ class Rate:
         # string is output to the terminal, rid is used as a dict key,
         # and pretty_string is latex
 
+        lhs_other = []
+        rhs_other = []
+
         self.string = ""
         self.rid = ""
         self.pretty_string = r"$"
@@ -402,7 +402,7 @@ class Rate:
 
         if strong_test:
             if len(self.products) == 1:
-                self.rhs_other.append("gamma")
+                rhs_other.append("gamma")
         else:
             # this is a weak rate
 
@@ -414,31 +414,31 @@ class Rate:
                 # the charge on the left should be +1 the charge on the right
                 assert sum(n.Z for n in self.reactants) == sum(n.Z for n in self.products) + 1
 
-                self.lhs_other.append("e-")
-                self.rhs_other.append("nu")
+                lhs_other.append("e-")
+                rhs_other.append("nu")
 
             elif self.weak_type == "beta_decay":
                 # we expect an electron on the right
                 assert sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products)
 
-                self.rhs_other.append("e-")
-                self.rhs_other.append("nubar")
+                rhs_other.append("e-")
+                rhs_other.append("nubar")
 
             elif "_pos_" in self.weak_type:
 
                 # we expect a positron on the right -- let's make sure
                 assert sum(n.Z for n in self.reactants) == sum(n.Z for n in self.products) + 1
 
-                self.rhs_other.append("e+")
-                self.rhs_other.append("nu")
+                rhs_other.append("e+")
+                rhs_other.append("nu")
 
             elif "_neg_" in self.weak_type:
 
                 # we expect an electron on the right -- let's make sure
                 assert sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products)
 
-                self.rhs_other.append("e-")
-                self.rhs_other.append("nubar")
+                rhs_other.append("e-")
+                rhs_other.append("nubar")
 
             else:
 
@@ -446,13 +446,13 @@ class Rate:
                 # not an electron capture
 
                 if sum(n.Z for n in self.reactants) == sum(n.Z for n in self.products) + 1:
-                    self.rhs_other.append("e+")
-                    self.rhs_other.append("nu")
+                    rhs_other.append("e+")
+                    rhs_other.append("nu")
 
                 elif sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products):
 
-                    self.rhs_other.append("e-")
-                    self.rhs_other.append("nubar")
+                    rhs_other.append("e-")
+                    rhs_other.append("nubar")
 
         for n, r in enumerate(treactants):
             self.string += f"{r.c()}"
@@ -463,8 +463,8 @@ class Rate:
                 self.rid += " + "
                 self.pretty_string += r" + "
 
-        if self.lhs_other:
-            for o in self.lhs_other:
+        if lhs_other:
+            for o in lhs_other:
                 if o == "e-":
                     self.string += " + e⁻"
                     self.pretty_string += r" + \mathrm{e}^-"
@@ -482,8 +482,8 @@ class Rate:
                 self.rid += " + "
                 self.pretty_string += r" + "
 
-        if self.rhs_other:
-            for o in self.rhs_other:
+        if rhs_other:
+            for o in rhs_other:
                 if o == "gamma":
                     self.string += " + 𝛾"
                     self.pretty_string += r"+ \gamma"
@@ -639,12 +639,6 @@ class ReacLibRate(Rate):
         self.reverse = None
 
         self.Q = Q
-
-        # some rates will have no nuclei particles (e.g. gamma) on the left or
-        # right -- we'll try to infer those here
-
-        self.lhs_other = []
-        self.rhs_other = []
 
         if isinstance(rfile, str):
             # read in the file, parse the different sets and store them as
@@ -1239,12 +1233,6 @@ class TabularRate(Rate):
         self.tabular = True
 
         self.Q = None
-
-        # some rates will have no nuclei particles (e.g. gamma) on the left or
-        # right -- we'll try to infer those here
-
-        self.lhs_other = []
-        self.rhs_other = []
 
         # we should initialize this somehow
         self.weak_type = ""

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -308,9 +308,6 @@ class Rate:
 
         self.weak_type = weak_type
 
-        # some rates will have no nuclei particles (e.g. gamma) on the left or
-        # right -- we'll try to infer those here
-
         self._set_rhs_properties()
         self._set_screening()
         self._set_print_representation()
@@ -376,6 +373,8 @@ class Rate:
         # string is output to the terminal, rid is used as a dict key,
         # and pretty_string is latex
 
+        # some rates will have no nuclei particles (e.g. gamma) on the left or
+        # right -- we'll try to infer those here
         lhs_other = []
         rhs_other = []
 

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -1312,6 +1312,13 @@ class TabularRate(Rate):
         self.table_index_name = f'j_{self.reactants[0]}_{self.products[0]}'
         self.labelprops = 'tabular'
 
+        # set weak type
+        if "electroncapture" in self.table_file:
+            self.weak_type = "electron_capture"
+
+        elif "betadecay" in self.table_file:
+            self.weak_type = "beta_decay"
+
     def _set_rhs_properties(self):
         """ compute statistical prefactor and density exponent from the reactants. """
         self.prefactor = 1.0  # this is 1/2 for rates like a + a (double counting)

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -417,6 +417,13 @@ class Rate:
                 self.lhs_other.append("e-")
                 self.rhs_other.append("nu")
 
+            elif self.weak_type == "beta_decay":
+                # we expect an electron on the right
+                assert sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products)
+
+                self.rhs_other.append("e-")
+                self.rhs_other.append("nubar")
+
             elif "_pos_" in self.weak_type:
 
                 # we expect a positron on the right -- let's make sure
@@ -436,10 +443,10 @@ class Rate:
             else:
 
                 # we need to figure out what the rate is.  We'll assume that it is
-                # not an electron capture
+                # either an electron capture or beta decay
 
                 if sum(n.Z for n in self.reactants) == sum(n.Z for n in self.products) + 1:
-                    self.rhs_other.append("e+")
+                    self.lhs_other.append("e-")
                     self.rhs_other.append("nu")
 
                 elif sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products):
@@ -1332,8 +1339,6 @@ class TabularRate(Rate):
         """ tabular rates are not currently screened (they are e-capture or beta-decay)"""
         self.ion_screen = []
         self.symmetric_screen = []
-
-        super()._set_print_representation()
 
         if not self.fname:
             # This is used to determine which rates to detect as the same reaction

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -443,10 +443,10 @@ class Rate:
             else:
 
                 # we need to figure out what the rate is.  We'll assume that it is
-                # either an electron capture or beta decay
+                # not an electron capture
 
                 if sum(n.Z for n in self.reactants) == sum(n.Z for n in self.products) + 1:
-                    self.lhs_other.append("e-")
+                    self.rhs_other.append("e+")
                     self.rhs_other.append("nu")
 
                 elif sum(n.Z for n in self.reactants) + 1 == sum(n.Z for n in self.products):


### PR DESCRIPTION
Currently the strings for tabular rates are messed up. For example.

```
>>> na23e_capture = TabularRate("na23--ne23-toki",)
>>> na23e_capture.string
'Na23 ⟶ Ne23 + e⁺ + 𝜈 + e⁺ + 𝜈'
```
There is double counting and clearly not an electron capture like it should be.

Cause to these two problems:
1. Double counting comes from `TabularRate._set_screening()` calling `_set_print_representation()` which leads to double counting electrons/neutrinos and other non-nuclei particles. 
2. Misidentifying this rate as a positron decay occurs because we don't set the `weak_type` for tabular rates. 


Fixes to these two problems
1. Remove the `_set_print_representation()` in screening. I don't think it is necessary there.
2. I set the `weak_type` by checking if the filename has "electroncapture" or "betadecay" when we initially read the file. For this example that file is `23Na-23Ne_electroncapture.dat`

Additionally, edited the `Rat._set_print_representation` so that it explicitly looks for beta-decay weak types. And if no weak type is specified it defaults to electron capture or beta decay instead of the previous beta decay/positron decay.