### PR TITLE
fix C++ compilation with partition functions

### DIFF
--- a/pynucastro/networks/amrexastro_cxx_network.py
+++ b/pynucastro/networks/amrexastro_cxx_network.py
@@ -67,8 +67,10 @@ class AmrexAstroCxxNetwork(BaseCxxNetwork):
         # create a .net file with the nuclei properties
         with open(os.path.join(odir, "pynucastro.net"), "w") as of:
             for nuc in self.unique_nuclei:
-                of.write("{:25} {:6} {:6.1f} {:6.1f}\n".format(
-                    nuc.spec_name, nuc.short_spec_name, nuc.A, nuc.Z))
+                of.write(f"{nuc.spec_name:25} {nuc.short_spec_name:6} {nuc.A:6.1f} {nuc.Z:6.1f}\n")
+
+            for nuc in self.approx_nuclei:
+                  of.write(f"__extra_{nuc.spec_name:17} {nuc.short_spec_name:6} {nuc.A:6.1f} {nuc.Z:6.1f}\n")
 
         # write out some network properties
         with open(os.path.join(odir, "NETWORK_PROPERTIES"), "w") as of:

--- a/pynucastro/networks/amrexastro_cxx_network.py
+++ b/pynucastro/networks/amrexastro_cxx_network.py
@@ -70,7 +70,7 @@ class AmrexAstroCxxNetwork(BaseCxxNetwork):
                 of.write(f"{nuc.spec_name:25} {nuc.short_spec_name:6} {nuc.A:6.1f} {nuc.Z:6.1f}\n")
 
             for nuc in self.approx_nuclei:
-                  of.write(f"__extra_{nuc.spec_name:17} {nuc.short_spec_name:6} {nuc.A:6.1f} {nuc.Z:6.1f}\n")
+                of.write(f"__extra_{nuc.spec_name:17} {nuc.short_spec_name:6} {nuc.A:6.1f} {nuc.Z:6.1f}\n")
 
         # write out some network properties
         with open(os.path.join(odir, "NETWORK_PROPERTIES"), "w") as of:

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/pynucastro.net
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/pynucastro.net
@@ -2,3 +2,5 @@ helium-4                  he4       4.0    2.0
 magnesium-24              mg24     24.0   12.0
 silicon-28                si28     28.0   14.0
 sulfur-32                 s32      32.0   16.0
+__extra_aluminum-27       al27     27.0   13.0
+__extra_phosphorus-31     p31      31.0   15.0

--- a/pynucastro/networks/tests/test_derived_network.py
+++ b/pynucastro/networks/tests/test_derived_network.py
@@ -71,12 +71,12 @@ def fe52__p_mn51__derived(rate_eval, tf):
     rate_eval.fe52__p_mn51__derived = rate
 
 
-    # setting p partition function to 1.0 by default, independent of T
-    p_pf = 1.0
-
     # interpolating mn51 partition function
     mn51_pf_exponent = np.interp(tf.T9, xp=mn51_temp_array, fp=np.log10(mn51_pf_array))
     mn51_pf = 10.0**mn51_pf_exponent
+
+    # setting p partition function to 1.0 by default, independent of T
+    p_pf = 1.0
 
     # interpolating fe52 partition function
     fe52_pf_exponent = np.interp(tf.T9, xp=fe52_temp_array, fp=np.log10(fe52_pf_array))

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -1585,7 +1585,7 @@ class DerivedRate(ReacLibRate):
         if self.use_pf:
 
             fstring += "\n"
-            for nuc in self.rate.reactants + self.rate.products:
+            for nuc in set(self.rate.reactants + self.rate.products):
                 if nuc.partition_function:
                     fstring += f"    # interpolating {nuc} partition function\n"
                     fstring += f"    {nuc}_pf_exponent = np.interp(tf.T9, xp={nuc}_temp_array, fp=np.log10({nuc}_pf_array))\n"
@@ -1627,7 +1627,7 @@ class DerivedRate(ReacLibRate):
         if self.use_pf:
 
             fstring += "\n"
-            for nuc in self.rate.reactants + self.rate.products:
+            for nuc in set(self.rate.reactants + self.rate.products):
                 fstring += f"    Real {nuc}_pf, d{nuc}_pf_dT;\n"
 
                 if nuc.partition_function:


### PR DESCRIPTION
this fixes 2 issues:
* if the nucleus multiplicity in a rate is more than 1, then we were defining the partition function twice
* we need the intermediate nuclei as "extra" nuclei to get their partition functions.