### PR TITLE
Add gamma heating to tabular weak rates

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -356,7 +356,7 @@ class BaseCxxNetwork(ABC, RateCollection):
             for r in self.tabular_rates:
 
                 of.write(f'{idnt}tabular_evaluate({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data,\n')
-                of.write(f'{idnt}                 rhoy, state.T, rate, drate_dt, edot_nu);\n')
+                of.write(f'{idnt}                 rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);\n')
 
                 of.write(f'{idnt}rate_eval.screened_rates(k_{r.fname}) = rate;\n')
 
@@ -364,7 +364,7 @@ class BaseCxxNetwork(ABC, RateCollection):
                 of.write(f'{idnt}    rate_eval.dscreened_rates_dT(k_{r.fname}) = drate_dt;\n')
                 of.write(f'{idnt}}}\n')
 
-                of.write(f'{idnt}rate_eval.add_energy_rate(k_{r.fname}) = edot_nu;\n')
+                of.write(f'{idnt}rate_eval.add_energy_rate(k_{r.fname}) = edot_nu + edot_gamma;\n')
                 of.write('\n')
 
     def _ydot(self, n_indent, of):

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -184,7 +184,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     // Calculate tabular rates
 
-    Real rate, drate_dt, edot_nu;
+    Real rate, drate_dt, edot_nu, edot_gamma;
 
 
 }
@@ -242,7 +242,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal)
+    // include reaction neutrino losses (non-thermal) and gamma heating
 
     // Get the thermal neutrino losses
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -305,7 +305,7 @@ void
 tabular_evaluate(const table_t& table_meta,
                  const R& rhoy_table, const T& temp_table, const D& data,
                  const Real rhoy, const Real temp,
-                 Real& rate, Real& drate_dt, Real& edot_nu)
+                 Real& rate, Real& drate_dt, Real& edot_nu, Real& edot_gamma)
 {
 
 
@@ -319,9 +319,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate     = entries(jtab_rate);
-    drate_dt = entries(k_drate_dt);
-    edot_nu  = -entries(jtab_nuloss);
+    rate       = entries(jtab_rate);
+    drate_dt   = entries(k_drate_dt);
+    edot_nu    = -entries(jtab_nuloss);
+    edot_gamma = entries(jtab_gamma);
 }
 
 #endif

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -132,23 +132,23 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     // Calculate tabular rates
 
-    Real rate, drate_dt, edot_nu;
+    Real rate, drate_dt, edot_nu, edot_gamma;
 
     tabular_evaluate(j_na23_ne23_meta, j_na23_ne23_rhoy, j_na23_ne23_temp, j_na23_ne23_data,
-                     rhoy, state.T, rate, drate_dt, edot_nu);
+                     rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_na23__ne23) = rate;
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_na23__ne23) = drate_dt;
     }
-    rate_eval.add_energy_rate(k_na23__ne23) = edot_nu;
+    rate_eval.add_energy_rate(k_na23__ne23) = edot_nu + edot_gamma;
 
     tabular_evaluate(j_ne23_na23_meta, j_ne23_na23_rhoy, j_ne23_na23_temp, j_ne23_na23_data,
-                     rhoy, state.T, rate, drate_dt, edot_nu);
+                     rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_ne23__na23) = rate;
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_ne23__na23) = drate_dt;
     }
-    rate_eval.add_energy_rate(k_ne23__na23) = edot_nu;
+    rate_eval.add_energy_rate(k_ne23__na23) = edot_nu + edot_gamma;
 
 
 }
@@ -226,7 +226,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal)
+    // include reaction neutrino losses (non-thermal) and gamma heating
     enuc += C::Legacy::n_A * Y(Na23) * rate_eval.add_energy_rate(k_na23__ne23);
     enuc += C::Legacy::n_A * Y(Ne23) * rate_eval.add_energy_rate(k_ne23__na23);
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
@@ -315,7 +315,7 @@ void
 tabular_evaluate(const table_t& table_meta,
                  const R& rhoy_table, const T& temp_table, const D& data,
                  const Real rhoy, const Real temp,
-                 Real& rate, Real& drate_dt, Real& edot_nu)
+                 Real& rate, Real& drate_dt, Real& edot_nu, Real& edot_gamma)
 {
 
 
@@ -329,9 +329,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate     = entries(jtab_rate);
-    drate_dt = entries(k_drate_dt);
-    edot_nu  = -entries(jtab_nuloss);
+    rate       = entries(jtab_rate);
+    drate_dt   = entries(k_drate_dt);
+    edot_nu    = -entries(jtab_nuloss);
+    edot_gamma = entries(jtab_gamma);
 }
 
 #endif

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -82,7 +82,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     // Calculate tabular rates
 
-    Real rate, drate_dt, edot_nu;
+    Real rate, drate_dt, edot_nu, edot_gamma;
 
     <compute_tabular_rates>(1)
 
@@ -128,7 +128,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal)
+    // include reaction neutrino losses (non-thermal) and gamma heating
     <enuc_add_energy_rate>(1)
 
     // Get the thermal neutrino losses

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -306,7 +306,7 @@ void
 tabular_evaluate(const table_t& table_meta,
                  const R& rhoy_table, const T& temp_table, const D& data,
                  const Real rhoy, const Real temp,
-                 Real& rate, Real& drate_dt, Real& edot_nu)
+                 Real& rate, Real& drate_dt, Real& edot_nu, Real& edot_gamma)
 {
 
 
@@ -320,9 +320,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate     = entries(jtab_rate);
-    drate_dt = entries(k_drate_dt);
-    edot_nu  = -entries(jtab_nuloss);
+    rate       = entries(jtab_rate);
+    drate_dt   = entries(k_drate_dt);
+    edot_nu    = -entries(jtab_nuloss);
+    edot_gamma = entries(jtab_gamma);
 }
 
 #endif


### PR DESCRIPTION
Under certain conditions, it is favorable for the product of a weak reaction to be in an excited state (e.g. electron captures at high density). In this case, a gamma ray is emitted providing some heating. The Suzuki et al. rates do account for this and there is a column labeled "gamma-heating". From what I've looked at, this heating is generally small compared to the neutrino loss.

this PR simply adds the heating into the amrex networks, similarly to how neutrino losses are implemented.