### PR TITLE
Fix lots of pylint suggestions

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -497,65 +497,63 @@ class BaseCxxNetwork(ABC, RateCollection):
 
         decl = "MICROPHYSICS_UNUSED HIP_CONSTEXPR static AMREX_GPU_MANAGED amrex::Real"
 
-        if nuclei_pfs:
-            for n in nuclei_pfs:
-                if n.partition_function:
-                    npts = len(n.partition_function.temperature)
-                    assert len(n.partition_function.temperature) == len(n.partition_function.partition_function)
+        for n in nuclei_pfs:
+            if n.partition_function:
+                npts = len(n.partition_function.temperature)
+                assert len(n.partition_function.temperature) == len(n.partition_function.partition_function)
 
-                    # write the data out, but for readability, split it to 5 values per line
+                # write the data out, but for readability, split it to 5 values per line
 
-                    # number of points
+                # number of points
 
-                    of.write(f"{self.indent*n_indent}constexpr int {n}_npts = {npts};\n\n")
+                of.write(f"{self.indent*n_indent}constexpr int {n}_npts = {npts};\n\n")
 
-                    # first the temperature (in units of T9)
+                # first the temperature (in units of T9)
 
-                    of.write(f"{self.indent*n_indent}{decl} {n}_temp_array[{n}_npts] = {{\n")
+                of.write(f"{self.indent*n_indent}{decl} {n}_temp_array[{n}_npts] = {{\n")
 
-                    tdata = list(n.partition_function.temperature/1.0e9)
-                    while tdata:
-                        if len(tdata) >= 5:
-                            tmp = ", ".join([str(tdata.pop(0)) for _ in range(0, 5)])
-                            if tdata:
-                                tmp += ","
-                        else:
-                            tmp = ", ".join([str(tdata.pop(0)) for _ in range(0, len(tdata))])
+                tdata = list(n.partition_function.temperature/1.0e9)
+                while tdata:
+                    if len(tdata) >= 5:
+                        tmp = ", ".join([str(tdata.pop(0)) for _ in range(0, 5)])
+                        if tdata:
+                            tmp += ","
+                    else:
+                        tmp = ", ".join([str(tdata.pop(0)) for _ in range(0, len(tdata))])
 
-                        of.write(f"{2*self.indent*n_indent}{tmp}\n")
-                    of.write(f"{self.indent*n_indent}}};\n\n")
+                    of.write(f"{2*self.indent*n_indent}{tmp}\n")
+                of.write(f"{self.indent*n_indent}}};\n\n")
 
-                    # now the partition function itself -- this is log10
+                # now the partition function itself -- this is log10
 
-                    of.write(f"{self.indent*n_indent}// this is log10(partition function)\n\n")
+                of.write(f"{self.indent*n_indent}// this is log10(partition function)\n\n")
 
-                    of.write(f"{self.indent*n_indent}{decl} {n}_pf_array[{n}_npts] = {{\n")
+                of.write(f"{self.indent*n_indent}{decl} {n}_pf_array[{n}_npts] = {{\n")
 
-                    tdata = list(n.partition_function.partition_function)
-                    while tdata:
-                        if len(tdata) >= 5:
-                            tmp = ", ".join([str(np.log10(tdata.pop(0))) for _ in range(0, 5)])
-                            if tdata:
-                                tmp += ","
-                        else:
-                            tmp = ", ".join([str(np.log10(tdata.pop(0))) for _ in range(0, len(tdata))])
+                tdata = list(n.partition_function.partition_function)
+                while tdata:
+                    if len(tdata) >= 5:
+                        tmp = ", ".join([str(np.log10(tdata.pop(0))) for _ in range(0, 5)])
+                        if tdata:
+                            tmp += ","
+                    else:
+                        tmp = ", ".join([str(np.log10(tdata.pop(0))) for _ in range(0, len(tdata))])
 
-                        of.write(f"{2*self.indent*n_indent}{tmp}\n")
-                    of.write(f"{self.indent*n_indent}}};\n\n")
+                    of.write(f"{2*self.indent*n_indent}{tmp}\n")
+                of.write(f"{self.indent*n_indent}}};\n\n")
 
-                    of.write("\n")
+                of.write("\n")
 
     def _fill_parition_function_cases(self, n_indent, of):
 
         nuclei_pfs = self.get_nuclei_needing_partition_functions()
 
-        if nuclei_pfs:
-            for n in nuclei_pfs:
-                if n.partition_function:
+        for n in nuclei_pfs:
+            if n.partition_function:
 
-                    of.write(f"{self.indent*n_indent}case {n.cindex()}:\n")
-                    of.write(f"{self.indent*2*n_indent}part_fun::interpolate_pf(tfactors.T9, part_fun::{n}_npts, part_fun::{n}_temp_array, part_fun::{n}_pf_array, pf, dpf_dT);\n")
-                    of.write(f"{self.indent*2*n_indent}break;\n\n")
+                of.write(f"{self.indent*n_indent}case {n.cindex()}:\n")
+                of.write(f"{self.indent*2*n_indent}part_fun::interpolate_pf(tfactors.T9, part_fun::{n}_npts, part_fun::{n}_temp_array, part_fun::{n}_pf_array, pf, dpf_dT);\n")
+                of.write(f"{self.indent*2*n_indent}break;\n\n")
 
     def _fill_spin_state_cases(self, n_indent, of):
 

--- a/pynucastro/networks/python_network.py
+++ b/pynucastro/networks/python_network.py
@@ -74,8 +74,7 @@ class PythonNetwork(RateCollection):
 
             if rate_terms_str == "":
                 return ""
-            else:
-                ostr += rate_terms_str
+            ostr += rate_terms_str
 
             ostr += f"{indent}   )\n\n"
 
@@ -199,12 +198,11 @@ class PythonNetwork(RateCollection):
 
         nuclei_pfs = self.get_nuclei_needing_partition_functions()
 
-        if nuclei_pfs:
-            for n in nuclei_pfs:
-                if n.partition_function:
-                    of.write(f"{n}_temp_array = np.array({list(n.partition_function.temperature/1.0e9)})\n")
-                    of.write(f"{n}_pf_array = np.array({list(n.partition_function.partition_function)})\n")
-                    of.write("\n")
+        for n in nuclei_pfs:
+            if n.partition_function:
+                of.write(f"{n}_temp_array = np.array({list(n.partition_function.temperature/1.0e9)})\n")
+                of.write(f"{n}_pf_array = np.array({list(n.partition_function.partition_function)})\n")
+                of.write("\n")
 
         # rate_eval class
 

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -299,6 +299,7 @@ class ScreeningPair:
 
 class RateCollection:
     """ a collection of rates that together define a network """
+    # pylint: disable=too-many-public-methods
 
     pynucastro_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
@@ -456,6 +457,7 @@ class RateCollection:
                             cr.removed = False
 
                         cr.fname = None
+                        # pylint: disable-next=protected-access
                         cr._set_print_representation()
 
                         if cr not in self.derived_rates:
@@ -468,6 +470,7 @@ class RateCollection:
                             cr.removed = False
 
                         cr.fname = None
+                        # pylint: disable-next=protected-access
                         cr._set_print_representation()
 
                         if cr not in self.reaclib_rates:
@@ -567,10 +570,9 @@ class RateCollection:
 
         # we might have some reverse rates remaining for which there
         # were no forward rates -- add those now
-        if reverse_rates:
-            for rr in reverse_rates:
-                rp = RatePair(reverse=rr)
-                rate_pairs.append(rp)
+        for rr in reverse_rates:
+            rp = RatePair(reverse=rr)
+            rate_pairs.append(rp)
 
         return rate_pairs
 
@@ -612,17 +614,14 @@ class RateCollection:
         return _r
 
     def get_nuclei_needing_partition_functions(self):
-        """return a list of the nuclei that require partition
-        functions for one or more DerivedRates in the collection"""
+        """return a set of Nuclei that require partition functions for one or
+        more DerivedRates in the collection"""
 
-        rates_with_pfs = [q for q in self.all_rates if isinstance(q, DerivedRate) and q.use_pf]
-
-        if rates_with_pfs:
-            nuclei_pfs = []
-            for r in rates_with_pfs:
-                nuclei_pfs += r.reactants + r.products
-            return set(nuclei_pfs)
-        return None
+        nuclei_pfs = set()
+        for r in self.all_rates:
+            if isinstance(r, DerivedRate) and r.use_pf:
+                nuclei_pfs.update(r.reactants + r.products)
+        return nuclei_pfs
 
     def remove_nuclei(self, nuc_list):
         """remove the nuclei in nuc_list from the network along with any rates
@@ -675,7 +674,7 @@ class RateCollection:
 
         # make sure that the intermediate_nuclei list are Nuclei objects
         _inter_nuclei_remove = []
-        if intermediate_nuclei:
+        if intermediate_nuclei is not None:
             for nn in intermediate_nuclei:
                 if isinstance(nn, Nucleus):
                     _inter_nuclei_remove.append(nn)
@@ -1078,12 +1077,12 @@ class RateCollection:
         warnings.filterwarnings("ignore", category=RuntimeWarning)
 
         # This nested loops should fine-tune the initial guess if fsolve is unable to find a solution
-        while (j < 20):
+        while j < 20:
             i = 0
             guess = copy.deepcopy(init_guess)
             init_dx = 0.5
 
-            while (i < 20):
+            while i < 20:
                 u = fsolve(self._constraint_eq, guess, args=(u_c, state), xtol=tol, maxfev=800)
                 Xs = self._nucleon_fraction_nse(u, u_c, state)
                 n_e = self._evaluate_n_e(state, Xs)

--- a/pynucastro/nucdata/partition_function.py
+++ b/pynucastro/nucdata/partition_function.py
@@ -146,10 +146,9 @@ class PartitionFunction:
         except ValueError:
             print("invalid temperature")
             raise
-        else:
-            if self.interpolant_order == 0:
-                return 10**self.interpolant(T)
-            return 10**self.interpolant(T, ext='const')  # extrapolates keeping the boundaries fixed.
+        if self.interpolant_order == 0:
+            return 10**self.interpolant(T)
+        return 10**self.interpolant(T, ext='const')  # extrapolates keeping the boundaries fixed.
 
 
 class PartitionFunctionTable:

--- a/pynucastro/nucdata/spin_table.py
+++ b/pynucastro/nucdata/spin_table.py
@@ -22,12 +22,7 @@ class SpinTable:
         else:
             datafile_name = 'nubase2020_1.txt'
             nucdata_dir = os.path.dirname(os.path.realpath(__file__))
-            datafile_dir = os.path.join(os.path.join(nucdata_dir, 'AtomicMassEvaluation'), datafile_name)
-
-        if os.path.isfile(datafile_dir):
-            self.datafile = datafile_dir
-        else:
-            raise Exception('ERROR: The spin tabulated file was not found')
+            self.datafile = os.path.join(os.path.join(nucdata_dir, 'AtomicMassEvaluation'), datafile_name)
 
         self._read_table()
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -52,7 +52,7 @@ def _rate_name_to_nuc(name):
             if nuc.lower() in ["e", "nu", "_", "g", "gamma"]:
                 # first electrons and neutrins, and nothing
                 continue
-            elif nuc.lower() == "aa":
+            if nuc.lower() == "aa":
                 reactants.append(Nucleus("he4"))
                 reactants.append(Nucleus("he4"))
             else:
@@ -70,7 +70,7 @@ def _rate_name_to_nuc(name):
             if nuc.lower() in ["e", "nu", "_", "g", "gamma"]:
                 # first electrons and neutrinos, gammas, and nothing
                 continue
-            elif nuc.lower() == "aa":
+            if nuc.lower() == "aa":
                 products.append(Nucleus("he4"))
                 products.append(Nucleus("he4"))
             else:

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -478,11 +478,10 @@ class Rate:
                 self.rid += " + "
                 self.pretty_string += r" + "
 
-        if lhs_other:
-            for o in lhs_other:
-                if o == "e-":
-                    self.string += " + e⁻"
-                    self.pretty_string += r" + \mathrm{e}^-"
+        for o in lhs_other:
+            if o == "e-":
+                self.string += " + e⁻"
+                self.pretty_string += r" + \mathrm{e}^-"
 
         self.string += " ⟶ "
         self.rid += " --> "
@@ -497,23 +496,22 @@ class Rate:
                 self.rid += " + "
                 self.pretty_string += r" + "
 
-        if rhs_other:
-            for o in rhs_other:
-                if o == "gamma":
-                    self.string += " + 𝛾"
-                    self.pretty_string += r"+ \gamma"
-                elif o == "nu":
-                    self.string += " + 𝜈"
-                    self.pretty_string += r"+ \nu_e"
-                elif o == "nubar":
-                    self.string += " + 𝜈"
-                    self.pretty_string += r"+ \bar{\nu}_e"
-                if o == "e-":
-                    self.string += " + e⁻"
-                    self.pretty_string += r" + \mathrm{e}^-"
-                if o == "e+":
-                    self.string += " + e⁺"
-                    self.pretty_string += r" + \mathrm{e}^+"
+        for o in rhs_other:
+            if o == "gamma":
+                self.string += " + 𝛾"
+                self.pretty_string += r"+ \gamma"
+            elif o == "nu":
+                self.string += " + 𝜈"
+                self.pretty_string += r"+ \nu_e"
+            elif o == "nubar":
+                self.string += " + 𝜈"
+                self.pretty_string += r"+ \bar{\nu}_e"
+            if o == "e-":
+                self.string += " + e⁻"
+                self.pretty_string += r" + \mathrm{e}^-"
+            if o == "e+":
+                self.string += " + e⁺"
+                self.pretty_string += r" + \mathrm{e}^+"
 
         self.pretty_string += r"$"
 
@@ -716,7 +714,7 @@ class Rate:
 
         # composition dependence
         Y_term = 1.0
-        for n, r in enumerate(sorted(set(self.reactants))):
+        for r in sorted(set(self.reactants)):
             c = self.reactants.count(r)
             if y_i == r:
                 # take the derivative
@@ -753,6 +751,7 @@ class ReacLibRate(Rate):
                  reactants=None, products=None, sets=None, labelprops=None, Q=None):
         """ rfile can be either a string specifying the path to a rate file or
         an io.StringIO object from which to read rate information. """
+        # pylint: disable=super-init-not-called
 
         self.rfile_path = rfile_path
         self.rfile = None
@@ -1227,6 +1226,7 @@ class ReacLibRate(Rate):
 
     def eval_deriv(self, T, rhoY=None):
         """ evauate the derivative of reaction rate with respect to T """
+        _ = rhoY  # unused by this subclass
 
         tf = Tfactors(T)
         drdT = 0.0
@@ -1264,6 +1264,7 @@ class ReacLibRate(Rate):
         :rtype: matplotlib.figure.Figure
 
         """
+        _ = (rhoYmin, rhoYmax)  # unused by this subclass
 
         fig, ax = plt.subplots(figsize=figsize)
 
@@ -1293,6 +1294,7 @@ class TabularRate(Rate):
     def __init__(self, rfile=None, rfile_path=None):
         """ rfile can be either a string specifying the path to a rate file or
         an io.StringIO object from which to read rate information. """
+        super().__init__()
 
         self.rfile_path = rfile_path
         self.rfile = None
@@ -1303,13 +1305,8 @@ class TabularRate(Rate):
 
         self.fname = None
 
-        self.reactants = []
-        self.products = []
-
         self.label = "tabular"
         self.tabular = True
-
-        self.Q = None
 
         # we should initialize this somehow
         self.weak_type = ""
@@ -1556,7 +1553,7 @@ class DerivedRate(ReacLibRate):
     by the application of detailed balance to the forward reactions.
     """
 
-    def __init__(self, rate,  compute_Q=False, use_pf=False):
+    def __init__(self, rate, compute_Q=False, use_pf=False):
 
         self.use_pf = use_pf
         self.rate = rate


### PR DESCRIPTION
Notes on the non-trivial changes:

* `RateCollection.get_nuclei_needing_partition_functions()`: return an empty set instead of `None`
* `networks/python_network.py` & `networks/base_cxx_network.py`: the big diffs are just reduced nesting thanks to the previous change
* `nucdata/spin_table.py`: `self.datafile` will be opened in `_read_table()` which can raise a FileNotFoundError, so defer to that instead of raising our own exception