### PR TITLE
fix beta-decay table headers 

### DIFF
--- a/pynucastro/library/tabular/17o-17f_betadecay.dat
+++ b/pynucastro/library/tabular/17o-17f_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB ,    Q (17O-17F) = -2.7604 MeV
 ! Experimental energies and B(GT) are used. 
 !
-! rhoY T mu dQ Vs beta-decay-rate nu-erergy-loss gamma-energy
-! g/cm^3 K erg erg erg 1/s erg/s erg/s 
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 
 1.000000e+07 1.000000e+07 1.956582e-06 -4.143237e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.954820e-06 -4.116000e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/18o-18f_betadecay.dat
+++ b/pynucastro/library/tabular/18o-18f_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB ,   GT,    Q (18O-18F) = -1.6559 MeV 
 !Experimental data are used.
 !
-! rhoY T mu dQ Vs beta-decay-rate nu-erergy-loss gamma-energy
-! g/cm^3 K erg erg erg 1/s erg/s erg/s 
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 
 1.000000e+07 1.000000e+07 1.956582e-06 -4.143237e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.954820e-06 -4.116000e-08 1.111913e-08 0.000000e+00 0.000000e+00 0.000000e+00

--- a/pynucastro/library/tabular/20f-20ne_betadecay.dat
+++ b/pynucastro/library/tabular/20f-20ne_betadecay.dat
@@ -3,8 +3,8 @@
 ! Experimental data are taken into account,  energies, GT
 !FF: 20F(2+) -> 20Ne(0+) included
 !
-!Log(rhoY) Log(T) mu       dQ       Vs         decay-rate    nu-energy-loss  gamma-energy
-!                     (MeV)     (MeV)    (MeV)          (1/s)           (MeV/s)        (MeV/s)
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 -4.470082e-08 1.233679e-08 6.137761e-02 2.769359e-07 1.606828e-07
 1.000000e+07 1.584893e+07 1.953538e-06 -4.454060e-08 1.233679e-08 6.142710e-02 2.773265e-07 1.608123e-07
 1.000000e+07 2.511886e+07 1.950814e-06 -4.405995e-08 1.233679e-08 6.144407e-02 2.774740e-07 1.608556e-07

--- a/pynucastro/library/tabular/20o-20f_betadecay.dat
+++ b/pynucastro/library/tabular/20o-20f_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB   GT    Q(20O-20F) = 3.8135 MeV
 !Experimental data are taken into account
 !
-!Log(rhoY) Log(T) mu     dQ       Vs          decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.956582e-06 -4.143237e-08 1.111913e-08 4.160064e-02 9.003499e-08 7.043870e-08
 1.000000e+07 1.584893e+07 1.954820e-06 -4.116000e-08 1.111913e-08 4.180228e-02 9.072173e-08 7.078012e-08
 1.000000e+07 2.511886e+07 1.952096e-06 -4.080752e-08 1.111913e-08 4.191795e-02 9.114048e-08 7.099231e-08

--- a/pynucastro/library/tabular/21f-21ne_betadecay.dat
+++ b/pynucastro/library/tabular/21f-21ne_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB    GT     Q(21F-21Ne) = 5.6841 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs          decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 -4.471684e-08 1.235281e-08 1.623118e-01 6.990227e-07 1.378197e-07
 1.000000e+07 1.584893e+07 1.953538e-06 -4.446049e-08 1.235281e-08 1.624688e-01 7.001503e-07 1.380102e-07
 1.000000e+07 2.511886e+07 1.950814e-06 -4.412404e-08 1.235281e-08 1.625249e-01 7.005858e-07 1.380738e-07

--- a/pynucastro/library/tabular/21o-21f_betadecay.dat
+++ b/pynucastro/library/tabular/21o-21f_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB   GT    Q(21O-21F) = 8.1095 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs          decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.956582e-06 -4.143237e-08 1.111913e-08 1.714905e-01 7.630997e-07 7.593138e-07
 1.000000e+07 1.584893e+07 1.954820e-06 -4.116000e-08 1.111913e-08 1.717315e-01 7.645067e-07 7.608715e-07
 1.000000e+07 2.511886e+07 1.952096e-06 -4.080752e-08 1.111913e-08 1.718700e-01 7.653169e-07 7.617655e-07

--- a/pynucastro/library/tabular/22f-22ne_betadecay.dat
+++ b/pynucastro/library/tabular/22f-22ne_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB    GT     Q(22F-22Ne) = 10.818 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs          decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 -4.471684e-08 1.235281e-08 1.593602e-01 6.675615e-07 1.479944e-06
 1.000000e+07 1.584893e+07 1.953538e-06 -4.446049e-08 1.235281e-08 1.595402e-01 6.687308e-07 1.481751e-06
 1.000000e+07 2.511886e+07 1.950814e-06 -4.412404e-08 1.235281e-08 1.596063e-01 6.691775e-07 1.482420e-06

--- a/pynucastro/library/tabular/23Ne-23Na_betadecay.dat
+++ b/pynucastro/library/tabular/23Ne-23Na_betadecay.dat
@@ -1,8 +1,8 @@
 !23Ne (5/2+, 1.2+, 7/2+, 3/2+)  -> 23Na    beta-decay  USDB, with screening effects
 !Exp. data are used.             Q=4.37581 MeV
 ! 
-!Log(rhoY) Log(T) mu    dQ        Vs        e-cap-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 -4.790518e-08 1.361853e-08 1.753881e-02 6.140607e-08 4.434159e-09
 1.000000e+07 1.584893e+07 1.952256e-06 -4.758475e-08 1.361853e-08 1.755497e-02 6.150513e-08 4.440290e-09
 1.000000e+07 2.511886e+07 1.949533e-06 -4.726431e-08 1.361853e-08 1.755497e-02 6.153346e-08 4.442335e-09

--- a/pynucastro/library/tabular/23f-23ne_betadecay.dat
+++ b/pynucastro/library/tabular/23f-23ne_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB     Q=8.4635 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs        decay-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.955461e-06 -4.470082e-08 1.233679e-08 3.743346e-01 1.813645e-06 1.595404e-06
 1.000000e+07 1.584893e+07 1.953538e-06 -4.454060e-08 1.233679e-08 3.746709e-01 1.816014e-06 1.597372e-06
 1.000000e+07 2.511886e+07 1.950814e-06 -4.405995e-08 1.233679e-08 3.747917e-01 1.816914e-06 1.598099e-06

--- a/pynucastro/library/tabular/24na-24mg_betadecay.dat
+++ b/pynucastro/library/tabular/24na-24mg_betadecay.dat
@@ -1,8 +1,8 @@
 !24Na (4+, 1+, 2+, 2+, 1+, 3+, 5+, 3+, 2+) -> 24Mg,   beta-decay,  with screening effects
 !USDB                Q=5.5156 MeV
 !Experimental energies, exp. B(GT) for 4+(g.s.) -> 4+(4.12MeV), 3+(5.235MeV), FF 4+(g.s.)->2+(1.369MeV) included
-!Log(rhoY) Log(T) mu     dQ       Vs         decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 -5.094932e-08 1.483619e-08 4.903430e-06 4.041209e-12 3.235276e-11
 1.000000e+07 1.584893e+07 1.951135e-06 -5.072502e-08 1.483619e-08 4.924929e-06 4.066411e-12 3.249461e-11
 1.000000e+07 2.511886e+07 1.948411e-06 -5.040458e-08 1.483619e-08 4.929467e-06 4.072033e-12 3.252455e-11

--- a/pynucastro/library/tabular/24ne-24na_betadecay.dat
+++ b/pynucastro/library/tabular/24ne-24na_betadecay.dat
@@ -1,8 +1,8 @@
 !24Ne (0+, 2+) -> 24Na,  beta-decay,  with screening effects
 !USDB                          Q = 2.4663 MeV
 !Exp. energies and B(GT)  0+(g.s.) -> 1+(0.472, 1.3467 MeV)
-!Log(rhoY) Log(T) mu     dQ       Vs           decay-rate    nu-energy-loss  gamma-energy
-!                    (MeV)   (MeV)   (MeV)        (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.954179e-06 -4.788916e-08 1.360251e-08 2.149810e-03 3.040964e-09 1.699070e-09
 1.000000e+07 1.584893e+07 1.952256e-06 -4.764883e-08 1.360251e-08 2.162221e-03 3.065570e-09 1.709666e-09
 1.000000e+07 2.511886e+07 1.949533e-06 -4.731238e-08 1.360251e-08 2.166207e-03 3.074053e-09 1.713607e-09

--- a/pynucastro/library/tabular/25na-25mg_betadecay.dat
+++ b/pynucastro/library/tabular/25na-25mg_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB         Q=3.8349 MeV
 !Experimental are data used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs         decay-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 -5.094932e-08 1.483619e-08 1.024236e-02 2.877473e-08 6.440377e-09
 1.000000e+07 1.584893e+07 1.951135e-06 -5.072502e-08 1.483619e-08 1.024944e-02 2.880125e-08 6.446312e-09
 1.000000e+07 2.511886e+07 1.948411e-06 -5.040458e-08 1.483619e-08 1.024944e-02 2.880125e-08 6.446312e-09

--- a/pynucastro/library/tabular/25ne-25na_betadecay.dat
+++ b/pynucastro/library/tabular/25ne-25na_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB       Q=7.2981 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs         decay-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.967797e-06 -4.788916e-08 1.360251e-08 1.181623e+00 6.836460e-06 7.431069e-07
 1.000000e+07 1.584893e+07 1.965875e-06 -4.764883e-08 1.360251e-08 1.181512e+00 6.835673e-06 7.430214e-07
 1.000000e+07 2.511886e+07 1.963151e-06 -4.731238e-08 1.360251e-08 1.181525e+00 6.836146e-06 7.431240e-07

--- a/pynucastro/library/tabular/26na-26mg_betadecay.dat
+++ b/pynucastro/library/tabular/26na-26mg_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB      Q=9.3538 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs         decay-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 -5.094932e-08 1.483619e-08 6.617745e-01 3.985578e-06 2.301979e-06
 1.000000e+07 1.584893e+07 1.951135e-06 -5.072502e-08 1.483619e-08 6.617897e-01 3.985853e-06 2.302138e-06
 1.000000e+07 2.511886e+07 1.948411e-06 -5.040458e-08 1.483619e-08 6.617440e-01 3.985578e-06 2.301979e-06

--- a/pynucastro/library/tabular/27mg-27al_betadecay.dat
+++ b/pynucastro/library/tabular/27mg-27al_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB      Q = 2.6101 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu    dQ        Vs         decay-rate    nu-energy-loss  gamma-energy
-!                   (MeV)    (MeV)   (MeV)       (1/s)           (MeV/s)           (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 -5.392938e-08 1.606987e-08 6.681900e-04 7.825486e-10 9.510674e-10
 1.000000e+07 1.584893e+07 1.949853e-06 -5.370507e-08 1.606987e-08 6.681900e-04 7.825486e-10 9.508485e-10
 1.000000e+07 2.511886e+07 1.947129e-06 -5.340066e-08 1.606987e-08 6.675749e-04 7.816482e-10 9.501919e-10

--- a/pynucastro/library/tabular/27na-27mg_betadecay.dat
+++ b/pynucastro/library/tabular/27na-27mg_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB      Q=9.069 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T)  dQ     Vs      mu       e-cap-rate    nu-energy-loss  gamma-energy
-!                 (MeV)     (MeV)     (MeV)       (1/s)             (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 -5.094932e-08 1.483619e-08 1.952897e-06 2.459688e+00 1.619240e-05 4.785875e-06
 1.000000e+07 1.584893e+07 -5.072502e-08 1.483619e-08 1.951135e-06 2.459688e+00 1.619240e-05 4.786095e-06
 1.000000e+07 2.511886e+07 -5.040458e-08 1.483619e-08 1.948411e-06 2.459461e+00 1.619240e-05 4.785654e-06

--- a/pynucastro/library/tabular/28al-28si_betadecay.dat
+++ b/pynucastro/library/tabular/28al-28si_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB                    Q = 4.6423 MeV
 !Experimental data are used.
 !
-!Log(rhoY) Log(T) mu     dQ       Vs           decay-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)     (MeV)          (1/s)            (MeV/s)      (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.950494e-06 -5.682932e-08 1.730354e-08 4.362144e-03 9.997958e-09 1.243401e-08
 1.000000e+07 1.584893e+07 1.948571e-06 -5.660502e-08 1.730354e-08 4.361140e-03 9.993355e-09 1.242829e-08
 1.000000e+07 2.511886e+07 1.945848e-06 -5.630061e-08 1.730354e-08 4.358128e-03 9.984155e-09 1.242257e-08

--- a/pynucastro/library/tabular/28mg-28al_betadecay.dat
+++ b/pynucastro/library/tabular/28mg-28al_betadecay.dat
@@ -2,8 +2,8 @@
 !USDB   Q=1.8318 MeV
 !Experimental energies, B(GT)
 !
-!Log(rhoY) Log(T) mu     dQ       Vs          decay-rate    nu-energy-loss  gamma-energy
-!                      (MeV)   (MeV)     (MeV)      (1/s)               (MeV/s)       (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.951776e-06 -5.392938e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 1.584893e+07 1.949853e-06 -5.370507e-08 1.606987e-08 0.000000e+00 0.000000e+00 0.000000e+00
 1.000000e+07 2.511886e+07 1.947129e-06 -5.340066e-08 1.606987e-08 1.000000e-298 2.539284e-304 2.481483e-305

--- a/pynucastro/library/tabular/28na-28mg_betadecay.dat
+++ b/pynucastro/library/tabular/28na-28mg_betadecay.dat
@@ -1,8 +1,8 @@
 !28Na (1+, 2+, 3+, 2+, 2+) -> 28Mg,   beta-decay,  with screening effects
 !USDB      Q=14..030 MeV
 !Experimental energies, B(GT),  1+(g.s.), 2+(0.055MeV), 3+(1.131 MeV), 2+(1.254 MeV)
-!Log(rhoY) Log(T) mu     dQ       Vs           decay-rate    nu-energy-loss  gamma-energy
-!                     (MeV)   (MeV)     (MeV)       (1/s)            (MeV/s)        (MeV/s)  
+!rhoY        T            mu           dQ           Vs           e-cap-rate   nu-energy-loss gamma-energy
+!g/cm^3      K            erg          erg          erg          1/s          erg/s        erg/s
 1.000000e+07 1.000000e+07 1.952897e-06 -5.094932e-08 1.483619e-08 2.476281e+01 2.554532e-04 6.362258e-05
 1.000000e+07 1.584893e+07 1.951135e-06 -5.072502e-08 1.483619e-08 2.476281e+01 2.554532e-04 6.362258e-05
 1.000000e+07 2.511886e+07 1.948411e-06 -5.040458e-08 1.483619e-08 2.475711e+01 2.553944e-04 6.360794e-05


### PR DESCRIPTION
The beta-decay tables were not changed in #297 . This fixes that mistake