### PR TITLE
Improve pytest coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,6 @@ source_pkgs = pynucastro
 # don't include the test files themselves
 omit =
   */tests/*
+exclude_also =
+  def __repr__
+  raise NotImplementedError

--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -45,4 +45,4 @@ jobs:
         run: python setup.py develop --user
 
       - name: Run tests with pytest
-        run: pytest -v -s --cov=pynucastro --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb --ignore-glob="examples/rp-process/*"
+        run: pytest -v -s --cov=pynucastro --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb

--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -45,4 +45,4 @@ jobs:
         run: python setup.py develop --user
 
       - name: Run tests with pytest
-        run: pytest -v -s --cov=. --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb --ignore-glob="examples/rp-process/*"
+        run: pytest -v -s --cov=pynucastro --nbval --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb --ignore-glob="examples/rp-process/*"

--- a/examples/library-examples.ipynb
+++ b/examples/library-examples.ipynb
@@ -34,11 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pynucastro as pyna"
@@ -47,11 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mylibrary = pyna.ReacLibLibrary()"
@@ -73,11 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "all_nuclei = [\"p\", \"he4\", \"c12\", \"n13\", \"c13\", \"o14\", \"n14\", \"o15\", \"n15\"]"
@@ -95,11 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cno_library = mylibrary.linking_nuclei(all_nuclei, with_reverse=False)"
@@ -115,11 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cno_network = pyna.networks.PythonNetwork(libraries=cno_library)"
@@ -127,11 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "source": [
     "In the above, we construct a network from a `Library` object by passing the `Library` object to the `libraries` argument of the network constructor. To construct a network from multiple libraries, the `libraries` argument can also take a list of `Library` objects.\n",
     "\n",
@@ -141,11 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -212,11 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "c12_inexact_filter = pyna.RateFilter(reactants=['c12'], exact=False)"
@@ -236,11 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -283,11 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cago = c12_inexact_library.get_rate('c12 + he4 --> o16 <nac2_reaclib__>')"
@@ -296,11 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -333,11 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -382,11 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -441,11 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -490,11 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "alpha_network = pyna.PythonNetwork(libraries=alpha_library)"
@@ -510,11 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/rp-process/network.ipynb
+++ b/examples/rp-process/network.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pynucastro.rates import Library, RateFilter\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "full_lib = Library(\"reaclib_default2_20220329\")"
@@ -41,11 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Could introduce pp-chain nuclei (d, t, he3, be7, li7, etc.)\n",
@@ -59,11 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "core_lib = full_lib.linking_nuclei(core_nuclei)"
@@ -72,11 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def is_beta_plus(rate):\n",
@@ -95,11 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Restrict the library to these 7 reaction types\n",
@@ -123,11 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bintable = BindingTable()"
@@ -136,11 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from collections import deque\n",
@@ -193,11 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "limiter = product_limiter()\n",
@@ -230,11 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1427,11 +1387,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1641,11 +1597,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rp_net = PythonNetwork(libraries=[final_lib])"
@@ -1654,11 +1606,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# rp_net.write_network()"


### PR DESCRIPTION
Make pytest only count coverage on files in `pynucastro/`, add some standard exclusions to the coveragerc, and fix the metadata for some of the example notebooks so they work properly with nbval.