### PR TITLE
Loosen tabular test tolerances and don't fail on new rates

### DIFF
--- a/pynucastro/rates/tests/test_tabular_rates.py
+++ b/pynucastro/rates/tests/test_tabular_rates.py
@@ -108,4 +108,7 @@ class TestTabularRates:
 
         for r in self.rc.get_rates():
             rr = ys[r.reactants[0]] * r.eval(T, rhoY=rho*ye)
-            assert rr == approx(stored_rates[r.fname], rel=1.e-9, abs=1.e-100), f"rate: {r} does not agree"
+            if r.fname in stored_rates:
+                assert rr == approx(stored_rates[r.fname], rel=1.e-6, abs=1.e-100), f"rate: {r} does not agree"
+            else:
+                print(f"WARNING: missing tests for tabular rate {r}")


### PR DESCRIPTION
The tabular data used to generate the reference values only have 7 decimal digits of precision for the rates, and the original data from Suzuki et. al. only have 6 digits at most, so an rtol of 1e-9 is too strict.

Also print warnings if any rates are present in the library but not in the test file, rather than making the test fail.