### PR TITLE
Fix some development annoyances

### DIFF
--- a/pynucastro/networks/tests/test_cxx_amrexastro_approx_net.py
+++ b/pynucastro/networks/tests/test_cxx_amrexastro_approx_net.py
@@ -1,4 +1,6 @@
 # unit tests for rates
+import shutil
+
 import pytest
 
 import pynucastro as pyna
@@ -24,5 +26,7 @@ class TestAmrexAstroCxxNetwork:
         # files that will be ignored if present in the generated directory
         skip_files = []
 
+        # remove any previously generated files
+        shutil.rmtree(test_path, ignore_errors=True)
         fn.write_network(odir=test_path)
         compare_network_files(test_path, reference_path, skip_files)

--- a/pynucastro/networks/tests/test_cxx_amrexastro_net.py
+++ b/pynucastro/networks/tests/test_cxx_amrexastro_net.py
@@ -1,5 +1,6 @@
 # unit tests for rates
 import io
+import shutil
 
 import pytest
 
@@ -83,5 +84,7 @@ class TestAmrexAstroCxxNetwork:
             "23Ne-23Na_betadecay.dat",
         ]
 
+        # remove any previously generated files
+        shutil.rmtree(test_path, ignore_errors=True)
         fn.write_network(odir=test_path)
         compare_network_files(test_path, reference_path, skip_files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 
 [tool.pylint.MAIN]
 ignore = ['_python_reference']
+extension-pkg-allow-list = ['mpi4py']
 
 [tool.pylint."MESSAGES CONTROL"]
 disable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ generated-members = ["viridis", "bwr"]
 
 [tool.codespell]
 skip = ".git,*docs/build,*.bib"
+
+[tool.isort]
+known_first_party = ["pynucastro"]


### PR DESCRIPTION
* Make isort work properly from any directory
* Make pylint stop complaining about mpi4py if it's installed
* Remove any existing files before writing a C++ network in the unit tests