### PR TITLE
Remove generated files if a test passes

### DIFF
--- a/pynucastro/networks/tests/test_approx_python_net.py
+++ b/pynucastro/networks/tests/test_approx_python_net.py
@@ -1,5 +1,7 @@
 # unit tests for rates
 import importlib
+import os
+import sys
 
 import numpy as np
 import pytest
@@ -104,6 +106,12 @@ def he4_mg24__si28__removed(rate_eval, tf):
         for i in range(app.nnuc):
             assert answer[i] == approx(sol.y[i, -1])
 
+        # clean up generated files if the test passed
+        os.remove("app.py")
+        # remove imported module from cache
+        del app
+        del sys.modules["app"]
+
     def test_to_composition(self, pynet):
         pynet.write_network("app.py")
         app = importlib.import_module("app")
@@ -117,3 +125,9 @@ def he4_mg24__si28__removed(rate_eval, tf):
         comp_new = app.to_composition(Y)
 
         assert comp_new.X == comp_orig.X
+
+        # clean up generated files if the test passed
+        os.remove("app.py")
+        # remove imported module from cache
+        del app
+        del sys.modules["app"]

--- a/pynucastro/networks/tests/test_cxx_amrexastro_approx_net.py
+++ b/pynucastro/networks/tests/test_cxx_amrexastro_approx_net.py
@@ -30,3 +30,6 @@ class TestAmrexAstroCxxNetwork:
         shutil.rmtree(test_path, ignore_errors=True)
         fn.write_network(odir=test_path)
         compare_network_files(test_path, reference_path, skip_files)
+
+        # clean up generated files if the test passed
+        shutil.rmtree(test_path)

--- a/pynucastro/networks/tests/test_cxx_amrexastro_net.py
+++ b/pynucastro/networks/tests/test_cxx_amrexastro_net.py
@@ -88,3 +88,6 @@ class TestAmrexAstroCxxNetwork:
         shutil.rmtree(test_path, ignore_errors=True)
         fn.write_network(odir=test_path)
         compare_network_files(test_path, reference_path, skip_files)
+
+        # clean up generated files if the test passed
+        shutil.rmtree(test_path)

--- a/pynucastro/networks/tests/test_full_python_net.py
+++ b/pynucastro/networks/tests/test_full_python_net.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import pytest
 
@@ -34,3 +35,6 @@ class TestFullPythonNetwork:
         with open(os.path.join(test_path, test_file), "r") as generated, \
              open(os.path.join(base_path, reference_path, test_file), "r") as reference:
             assert generated.readlines() == reference.readlines()
+
+        # clean up generated files if the test passed
+        shutil.rmtree(test_path)

--- a/pynucastro/networks/tests/test_python_partition_functions.py
+++ b/pynucastro/networks/tests/test_python_partition_functions.py
@@ -1,3 +1,7 @@
+import importlib
+import os
+import sys
+
 import pytest
 
 import pynucastro as pyna
@@ -5,7 +9,7 @@ import pynucastro as pyna
 
 class TestPythonPartitionNetwork:
     @pytest.fixture(scope="class")
-    def fn(self, reaclib_library):
+    def pynet(self, reaclib_library):
 
         fwd_reactions = reaclib_library.derived_forward()
 
@@ -22,15 +26,13 @@ class TestPythonPartitionNetwork:
         der_rates_lib = pyna.Library(rates=derived)
         full_lib = fwd_rates_lib + der_rates_lib
 
-        pynet = pyna.PythonNetwork(libraries=[full_lib])
-        pynet.write_network("der_net.py")
+        return pyna.PythonNetwork(libraries=[full_lib])
 
-    def test_partition_rates(self, fn):
+    def test_partition_rates(self, pynet):
         """test the rate evaluation with partition functions from the
         python network"""
-        del fn
-
-        import der_net  # pylint: disable=import-outside-toplevel, import-error, useless-suppression
+        pynet.write_network("der_net.py")
+        der_net = importlib.import_module("der_net")
 
         T = 5.e9
         tf = pyna.Tfactors(T)
@@ -54,3 +56,9 @@ class TestPythonPartitionNetwork:
 
         assert rate_eval.p_co55__he4_fe52__derived == pytest.approx(15485.753590182012, rel=1.e-10)
         assert rate_eval.ni56__p_co55__derived == pytest.approx(428973340937.6744, rel=1.e-10)
+
+        # clean up generated files if the test passed
+        os.remove("der_net.py")
+        # remove imported module from cache
+        del der_net
+        del sys.modules["der_net"]


### PR DESCRIPTION
Leave the files from failing tests alone, so the user can inspect them.