### PR TITLE
fix a bounds issue in the C++ table interpolation

### DIFF
--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -228,7 +228,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
+    if ((itemp_lo - 1 < 1) || (itemp_hi + 1 > table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -239,7 +239,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp-1)) {
+    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
@@ -249,7 +249,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp-1)) {
+    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
@@ -238,7 +238,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
+    if ((itemp_lo - 1 < 1) || (itemp_hi + 1 > table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -240,7 +240,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp-1)) {
+    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -229,7 +229,7 @@ get_entries(const table_t& table_meta,
     // Calculate the derivative of rate with temperature, d(rate)/d(t)
     // (Clamp interpolations in rhoy to avoid unphysical temperature derivatives)
 
-    if ((itemp_lo == 1) || (itemp_hi == table_meta.ntemp)) {
+    if ((itemp_lo - 1 < 1) || (itemp_hi + 1 > table_meta.ntemp)) {
         // We're at the first or last table cell (in temperature)
         // First do bilinear interpolation in rhoy for the table at tlo and thi
 


### PR DESCRIPTION
at high temperature, we were going out of bounds when computing the derivative