### PR TITLE
set requirement for numpy<2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 networkx>=2.1
 scipy>=1.0.0
-numpy>=1.13.3
+numpy>=1.13.3,<2.0
 sympy>=1.1.1
 matplotlib>=2.1.0
 jupyter>=1.0.0


### PR DESCRIPTION
numpy 2.0 will be released in Dec/Jan, and they are recommending packages to put a < 2 version in their requirements until things are tested