### PR TITLE
remove NSE_INDEX::initialized

### DIFF
--- a/pynucastro/networks/amrexastro_cxx_network.py
+++ b/pynucastro/networks/amrexastro_cxx_network.py
@@ -149,4 +149,3 @@ class AmrexAstroCxxNetwork(BaseCxxNetwork):
             of.write(f"{self.indent*n_indent}    {reactant_ind[0]}, {reactant_ind[1]}, {reactant_ind[2]}, {product_ind[0]}, {product_ind[1]}, {product_ind[2]}, {rr_ind}{tmp}\n")
 
         of.write(f"{self.indent*n_indent}}};\n")
-        of.write(f"{self.indent*n_indent}AMREX_GPU_MANAGED bool initialized = false;\n")

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_network.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_network.H
@@ -89,7 +89,6 @@ namespace NSE_INDEX
     // last index is the corresponding reverse rate index.
 
     extern AMREX_GPU_MANAGED amrex::Array2D<int, 1, Rates::NumRates, 1, 7, Order::C> rate_indices;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_network_data.cpp
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_network_data.cpp
@@ -28,7 +28,6 @@ namespace NSE_INDEX
         -1, 0, 2, -1, -1, 3, 16,
         -1, -1, 3, -1, 0, 2, -1
     };
-    AMREX_GPU_MANAGED bool initialized = false;
 }
 #endif
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_network.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_network.H
@@ -71,7 +71,6 @@ namespace NSE_INDEX
     // last index is the corresponding reverse rate index.
 
     extern AMREX_GPU_MANAGED amrex::Array2D<int, 1, Rates::NumRates, 1, 7, Order::C> rate_indices;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_network_data.cpp
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_network_data.cpp
@@ -19,7 +19,6 @@ namespace NSE_INDEX
         -1, -1, 7, -1, -1, 6, -1,
         -1, -1, 6, -1, -1, 7, 6
     };
-    AMREX_GPU_MANAGED bool initialized = false;
 }
 #endif
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_network.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_network.H.template
@@ -56,7 +56,6 @@ namespace NSE_INDEX
     // last index is the corresponding reverse rate index.
 
     extern AMREX_GPU_MANAGED amrex::Array2D<int, 1, Rates::NumRates, 1, 7, Order::C> rate_indices;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 


### PR DESCRIPTION
with new pr 1279 in microphysics, this is no longer needed.