### PR TITLE
Move numpy AVX-512 workaround to conftest.py

### DIFF
--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -52,12 +52,7 @@ jobs:
           lscpu
 
       - name: Run tests with pytest
-        run: |
-          # Numpy 1.24 gets slightly diff output: https://github.com/numpy/numpy/issues/23523
-          export NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512_SKX"
-          # ignore RuntimeWarning for unsupported CPU features, as it breaks nbval
-          export PYTHONWARNINGS="ignore:During parsing environment variable 'NPY_DISABLE_CPU_FEATURES':RuntimeWarning::"
-          pytest -v -s --nbval --cov=pynucastro --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb
+        run: pytest -v -s --nbval --cov=pynucastro --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb
 
       - name: Upload output from failed write_network tests
         uses: actions/upload-artifact@v3

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,39 @@
+"""
+Recent versions of numpy use AVX-512 routines from SVML to speed up some math
+functions on processors that support it. These implementations allow a maximum
+error of 4 ULP, which is looser than in previous versions. Our tests for
+write_network() (and probably some others) expect exactly reproducible floating
+point values, which may differ between the AVX-512 and fallback
+implementations. Unfortunately, not all of Github's runners support AVX-512, so
+we get unpredictable CI failures depending on what hardware the tests run on.
+
+For now, we're disabling these features when running the test suite with the
+NPY_DISABLE_CPU_FEATURES environment variable. This needs to be set before
+numpy is imported for the first time, and will emit a RuntimeWarning if the
+disabled features are not supported by the machine.
+
+This may be fixed by https://github.com/numpy/numpy/pull/24006, which uses the
+high accuracy (within 1 ULP) SVML routines for float64 values.
+
+Related numpy PRs and issues:
+  https://github.com/numpy/numpy/pull/19478
+  https://github.com/numpy/numpy/pull/20991
+  https://github.com/numpy/numpy/pull/22240
+  https://github.com/numpy/numpy/issues/23523
+"""
+import os
+import warnings
+
+os.environ["NPY_DISABLE_CPU_FEATURES"] = "AVX512F AVX512CD AVX512_SKX"
+
+# ignore all NPY_DISABLE_CPU_FEATURES warnings in any subprocesses
+# need this for nbval as it expects stderr to be empty
+os.environ["PYTHONWARNINGS"] = "ignore:During parsing environment variable 'NPY_DISABLE_CPU_FEATURES':RuntimeWarning::"
+with warnings.catch_warnings():
+    # ignore just the "not supported by your machine" warning for the standard pytest tests
+    warnings.filterwarnings(
+        action="ignore",
+        message=r"(?s)During parsing environment variable 'NPY_DISABLE_CPU_FEATURES'.*not supported by your machine",
+        category=RuntimeWarning
+    )
+    import numpy  # noqa[F401]  # pylint: disable=unused-import


### PR DESCRIPTION
This disables the AVX-512 routines when running pytest (both in CI and locally), which I needed in order to reproduce the same results as Github Actions on my machine.

It needs to go into the root of the repository because the environment variable has to be set before numpy is first imported. If we put it in `pynucastro/conftest.py`, pytest would import `pynucastro/__init__.py` first.