### PR TITLE
Change T to tf when writing custom rates

### DIFF
--- a/pynucastro/networks/python_network.py
+++ b/pynucastro/networks/python_network.py
@@ -140,7 +140,7 @@ class PythonNetwork(RateCollection):
         if self.custom_rates:
             ostr += f"\n{indent}# custom rates\n"
         for r in self.custom_rates:
-            ostr += f"{indent}{r.fname}(rate_eval, T)\n"
+            ostr += f"{indent}{r.fname}(rate_eval, tf)\n"
 
         ostr += "\n"
 


### PR DESCRIPTION
Fixed typo. When writing custom rates the temperature should be given as tf.