### PR TITLE
fix get_rate_by_name to work with a rate with "pp"

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1966,7 +1966,7 @@ class RateCollection:
         highlight_edges = [(u, v) for u, v, e in G.edges(data=True) if e["highlight"]]
 
         _ = nx.draw_networkx_edges(G, G.position, width=5,
-                                   edgelist=highlight_edges, edge_color="C0", alpha="0.25",
+                                   edgelist=highlight_edges, edge_color="yellow", alpha="0.25",
                                    connectionstyle=connectionstyle,
                                    node_size=node_size, ax=ax)
 

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1966,7 +1966,7 @@ class RateCollection:
         highlight_edges = [(u, v) for u, v, e in G.edges(data=True) if e["highlight"]]
 
         _ = nx.draw_networkx_edges(G, G.position, width=5,
-                                   edgelist=highlight_edges, edge_color="yellow", alpha="0.25",
+                                   edgelist=highlight_edges, edge_color="C0", alpha="0.25",
                                    connectionstyle=connectionstyle,
                                    node_size=node_size, ax=ax)
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -61,9 +61,8 @@ def _rate_name_to_nuc(name):
                 reactants.append(Nucleus("he4"))
                 reactants.append(Nucleus("he4"))
                 continue
-            else:
-                print(f"couldn't deal with {nuc}")
-                raise
+            print(f"couldn't deal with {nuc}")
+            raise
 
     products = []
     for nuc in _p:
@@ -85,9 +84,8 @@ def _rate_name_to_nuc(name):
                 products.append(Nucleus("he4"))
                 products.append(Nucleus("he4"))
                 continue
-            else:
-                print(f"couldn't deal with {nuc}")
-                raise
+            print(f"couldn't deal with {nuc}")
+            raise
 
     return reactants, products
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -73,7 +73,6 @@ def _rate_name_to_nuc(name):
             n = Nucleus(nuc)
             products.append(n)
         except (ValueError, AssertionError):
-            print(nuc)
             # we need to interpret some things specially
             if nuc.lower() in ["e", "nu", "_", "g", "gamma"]:
                 # first electrons and neutrinos, gammas, and nothing

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -53,10 +53,16 @@ def _rate_name_to_nuc(name):
             if nuc.lower() in ["e", "nu", "_", "g", "gamma"]:
                 # first electrons and neutrins, and nothing
                 continue
+            if nuc.lower() == "pp":
+                reactants.append(Nucleus("p"))
+                reactants.append(Nucleus("p"))
+                continue
             if nuc.lower() == "aa":
                 reactants.append(Nucleus("he4"))
                 reactants.append(Nucleus("he4"))
+                continue
             else:
+                print(f"couldn't deal with {nuc}")
                 raise
 
     products = []
@@ -67,14 +73,21 @@ def _rate_name_to_nuc(name):
             n = Nucleus(nuc)
             products.append(n)
         except (ValueError, AssertionError):
+            print(nuc)
             # we need to interpret some things specially
             if nuc.lower() in ["e", "nu", "_", "g", "gamma"]:
                 # first electrons and neutrinos, gammas, and nothing
                 continue
+            if nuc.lower() == "pp":
+                products.append(Nucleus("p"))
+                products.append(Nucleus("p"))
+                continue
             if nuc.lower() == "aa":
                 products.append(Nucleus("he4"))
                 products.append(Nucleus("he4"))
+                continue
             else:
+                print(f"couldn't deal with {nuc}")
                 raise
 
     return reactants, products


### PR DESCRIPTION
for example, in the p-p chain, we have
"he3(he3,pp)he4"
we will now correctly get the rate.  I also think we weren't handling the "aa" case correctly before.