### PR TITLE
remove ostream from validate

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -878,17 +878,12 @@ class RateCollection:
 
         return jac
 
-    def validate(self, other_library, forward_only=True, ostream=None):
+    def validate(self, other_library, *, forward_only=True):
         """perform various checks on the library, comparing to other_library,
         to ensure that we are not missing important rates.  The idea
         is that self should be a reduced library where we filtered out
         a few rates and then we want to compare to the larger
         other_library to see if we missed something important.
-
-        ostream is the I/O stream to send output to (for instance, a
-        file object or StringIO object).  If it is None, then output
-        is to stdout.
-
         """
 
         current_rates = sorted(self.get_rates())
@@ -914,10 +909,7 @@ class RateCollection:
                 if not found:
                     passed_validation = False
                     msg = f"validation: {p} produced in {rate} never consumed."
-                    if ostream is None:
-                        print(msg)
-                    else:
-                        ostream.write(msg + "\n")
+                    print(msg)
 
         # now check if we are missing any rates from other_library with the exact same reactants
 
@@ -938,10 +930,7 @@ class RateCollection:
 
                 if not found:
                     msg = f"validation: missing {other_rate} as alternative to {rate} (Q = {other_rate.Q} MeV)."
-                    if ostream is None:
-                        print(msg)
-                    else:
-                        ostream.write(msg + "\n")
+                    print(msg)
 
         return passed_validation
 

--- a/pynucastro/networks/tests/test_validate.py
+++ b/pynucastro/networks/tests/test_validate.py
@@ -1,6 +1,4 @@
 # unit tests for rates
-import io
-
 import pytest
 
 import pynucastro as pyna

--- a/pynucastro/networks/tests/test_validate.py
+++ b/pynucastro/networks/tests/test_validate.py
@@ -98,7 +98,6 @@ class TestValidate:
         return reaclib_library.linking_nuclei(all_reactants)
 
     def test_validate(self, reduced_library, reaclib_library, capsys):
-        output = io.StringIO()
         rc = pyna.RateCollection(libraries=[reduced_library])
         rc.validate(reaclib_library)
         captured = capsys.readouterr()

--- a/pynucastro/networks/tests/test_validate.py
+++ b/pynucastro/networks/tests/test_validate.py
@@ -97,8 +97,9 @@ class TestValidate:
 
         return reaclib_library.linking_nuclei(all_reactants)
 
-    def test_validate(self, reduced_library, reaclib_library):
+    def test_validate(self, reduced_library, reaclib_library, capsys):
         output = io.StringIO()
         rc = pyna.RateCollection(libraries=[reduced_library])
-        rc.validate(reaclib_library, ostream=output)
-        assert ANSWER == output.getvalue()
+        rc.validate(reaclib_library)
+        captured = capsys.readouterr()
+        assert ANSWER == captured.out


### PR DESCRIPTION
this was only used for testing, and we can use pytest's capsys instead.
Also switch to keyword-only args