### PR TITLE
add an exclude option to bin_as

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -197,21 +197,23 @@ class Composition:
         new_comp = Composition(nuclei)
 
         # first do any exact matches if we provided an exclude list
-        if exclude:
-            for ex_nuc in exclude:
-                # if the exclude nucleus is in both our original
-                # composition and the reduced composition, then set
-                # the abundance in the new, reduced composition and
-                # remove the nucleus from consideration for the other
-                # original nuclei
-                if ex_nuc in nuclei and ex_nuc in self.X:
-                    nuclei.remove(ex_nuc)
-                    new_comp.X[ex_nuc] = self.X[ex_nuc]
-                    if verbose:
-                        print(f"storing {ex_nuc} as {ex_nuc}")
+        if exclude is None:
+            exclude = []
 
-                else:
-                    raise ValueError("cannot use exclude if nucleus is not present in both the original and new compostion")
+        for ex_nuc in exclude:
+            # if the exclude nucleus is in both our original
+            # composition and the reduced composition, then set
+            # the abundance in the new, reduced composition and
+            # remove the nucleus from consideration for the other
+            # original nuclei
+            if ex_nuc in nuclei and ex_nuc in self.X:
+                nuclei.remove(ex_nuc)
+                new_comp.X[ex_nuc] = self.X[ex_nuc]
+                if verbose:
+                    print(f"storing {ex_nuc} as {ex_nuc}")
+
+            else:
+                raise ValueError("cannot use exclude if nucleus is not present in both the original and new compostion")
 
         # loop over our original nuclei.  Find the new nucleus such
         # that n_orig.A >= n_new.A.  If there are multiple, then do

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -220,10 +220,9 @@ class Composition:
         # the same for Z
         for old_n, v in self.X.items():
 
-            if exclude:
-                if old_n in exclude:
-                    # we should have already dealt with this above
-                    continue
+            if old_n in exclude:
+                # we should have already dealt with this above
+                continue
 
             candidates = [q for q in nuclei if old_n.A >= q.A]
             # if candidates is empty, then all of the nuclei are heavier than

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -182,9 +182,13 @@ class Composition:
         """ return the mean charge, Zbar """
         return self.eval_abar() * self.eval_ye()
 
-    def bin_as(self, nuclei, *, verbose=False):
+    def bin_as(self, nuclei, *, verbose=False, exclude=None):
         """given a list of nuclei, return a new Composition object with the
-        current composition mass fractions binned into the new nuclei."""
+        current composition mass fractions binned into the new nuclei.
+
+        if a list of nuclei is provided by exclude, then only exact
+        matches will be binned into the nuclei in that list
+        """
 
         # sort the input nuclei by A, then Z
         nuclei.sort(key=lambda n: (n.A, n.Z))
@@ -192,10 +196,32 @@ class Composition:
         # create the new composition
         new_comp = Composition(nuclei)
 
+        # first do any exact matches if we provided an exclude list
+        if exclude:
+            for ex_nuc in exclude:
+                # if the exclude nucleus is in both our original
+                # composition and the reduced composition, then set
+                # the abundance in the new, reduced composition and
+                # remove the nucleus from consideration for the other
+                # original nuclei
+                if ex_nuc in nuclei and ex_nuc in self.X:
+                    nuclei.remove(ex_nuc)
+                    new_comp.X[ex_nuc] = self.X[ex_nuc]
+                    if verbose:
+                        print(f"storing {ex_nuc} as {ex_nuc}")
+
+                else:
+                    raise ValueError("cannot use exclude if nucleus is not present in both the original and new compostion")
+
         # loop over our original nuclei.  Find the new nucleus such
         # that n_orig.A >= n_new.A.  If there are multiple, then do
         # the same for Z
         for old_n, v in self.X.items():
+
+            if exclude:
+                if old_n in exclude:
+                    # we should have already dealt with this above
+                    continue
 
             candidates = [q for q in nuclei if old_n.A >= q.A]
             # if candidates is empty, then all of the nuclei are heavier than

--- a/pynucastro/networks/tests/test_composition.py
+++ b/pynucastro/networks/tests/test_composition.py
@@ -2,6 +2,7 @@
 import pytest
 from pytest import approx
 
+import pynucastro as pyna
 from pynucastro import networks
 from pynucastro.nucdata import Nucleus
 
@@ -195,3 +196,58 @@ class TestCompBinning2:
 
         # we should have placed O18 into F18
         assert c_new.X[Nucleus("f18")] == approx(orig_X)
+
+
+class TestCompBinning3:
+    """an example where we exclude Ni56 from the binning."""
+    @pytest.fixture(scope="class")
+    def nuclei(self):
+        nuc_list = pyna.get_nuclei_in_range(26, 26, 52, 58)
+        nuc_list += pyna.get_nuclei_in_range(28, 28, 56, 58)
+        return nuc_list
+
+    @pytest.fixture(scope="class")
+    def comp(self, nuclei):
+        c = networks.Composition(nuclei)
+        c.set_equal()
+        return c
+
+    def test_bin_as(self, nuclei, comp):
+        """first bin without exclusion"""
+
+        new_nuclei = [Nucleus("fe52"), Nucleus("fe54"), Nucleus("ni56")]
+
+        c_new = comp.bin_as(new_nuclei)
+
+        assert c_new.get_sum_X() == approx(comp.get_sum_X())
+
+        orig_X = 1.0 / len(nuclei)
+
+        # we should have placed fe52, fe53 into fe52
+        assert c_new.X[Nucleus("fe52")] == approx(2.0 * orig_X)
+
+        # we should have placed fe54, fe55 into fe54
+        assert c_new.X[Nucleus("fe54")] == approx(2.0 * orig_X)
+
+        # everything else should be ni56
+        assert c_new.X[Nucleus("ni56")] == approx(6.0 * orig_X)
+
+    def test_bin_as_exclude(self, nuclei, comp):
+        """exclude Ni56"""
+
+        new_nuclei = [Nucleus("fe52"), Nucleus("fe54"), Nucleus("ni56")]
+
+        c_new = comp.bin_as(new_nuclei, exclude=[Nucleus("ni56")])
+
+        assert c_new.get_sum_X() == approx(comp.get_sum_X())
+
+        orig_X = 1.0 / len(nuclei)
+
+        # we should have placed fe52, fe53 into fe52
+        assert c_new.X[Nucleus("fe52")] == approx(2.0 * orig_X)
+
+        # we should have placed fe54, fe55, fe56, fe57, fe58, ni57, ni58 into fe54
+        assert c_new.X[Nucleus("fe54")] == approx(7.0 * orig_X)
+
+        # only ni56 should be ni56
+        assert c_new.X[Nucleus("ni56")] == approx(orig_X)


### PR DESCRIPTION
this is useful, for example, to preserve the amount if Ni56 when we bin down a composition