### PR TITLE
simplify how we account for weak rate neutrino loss

### DIFF
--- a/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
+++ b/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
@@ -1,4 +1,4 @@
-AMReX (23.07-106-gde7c6189623b-dirty) initialized
+AMReX (23.10-13-gecaa14456e3f) initialized
 starting the single zone burn...
 reading in network electron-capture / beta-decay tables...
 Maximum Time (s): 0.01
@@ -29,37 +29,37 @@ RHS at t = 0
    s32 1323519.174
 ------------------------------------
 successful? 1
- - Hnuc = 4.716248406e+19
- - added e = 4.716248406e+17
- - final T = 6804058463
+ - Hnuc = 4.4691188e+19
+ - added e = 4.4691188e+17
+ - final T = 6711517341
 ------------------------------------
 e initial = 5.995956082e+17
-e final =   1.071220449e+18
+e final =   1.046507488e+18
 ------------------------------------
 new mass fractions: 
-h1 0.009032124504
-he4 4.003293528e-13
-o16 5.888714278e-07
-o20 0.00985678636
-f20 0.009855432543
-ne20 7.501479981e-14
-mg24 1.21710929e-09
-al27 1.951815457e-21
-si28 0.26794899
-p31 8.245884489e-14
-s32 0.7033060765
+h1 0.007036728874
+he4 4.569221711e-13
+o16 6.11671909e-07
+o20 0.009363850335
+f20 0.009362566168
+ne20 8.595667728e-14
+mg24 8.576669062e-06
+al27 9.999999996e-31
+si28 0.2286832772
+p31 9.999999996e-31
+s32 0.745544389
 ------------------------------------
 species creation rates: 
-omegadot(h1): -0.0967875496
+omegadot(h1): -0.2963271126
 omegadot(he4): -3
-omegadot(o16): -49.99994111
-omegadot(o20): -0.01432136399
-omegadot(f20): -0.0144567457
+omegadot(o16): -49.99993883
+omegadot(o20): -0.0636149665
+omegadot(f20): -0.06374338321
 omegadot(ne20): -30
-omegadot(mg24): -9.999999878
+omegadot(mg24): -9.999142333
 omegadot(al27): -1
-omegadot(si28): 25.794899
+omegadot(si28): 21.86832772
 omegadot(p31): -1
-omegadot(s32): 69.33060765
-number of steps taken: 31502
-AMReX (23.07-106-gde7c6189623b-dirty) finalized
+omegadot(s32): 73.5544389
+number of steps taken: 14714
+AMReX (23.10-13-gecaa14456e3f) finalized

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -341,7 +341,7 @@ class BaseCxxNetwork(ABC, RateCollection):
                 of.write(f'{idnt}    rate_eval.dscreened_rates_dT(k_{r.cname()}) = drate_dt;\n')
                 of.write(f'{idnt}}}\n')
 
-                of.write(f'{idnt}enuc_weak += C::Legacy::n_A * {self.symbol_rates.name_y}({r.reactants[0].cindex()}) * (edot_nu + edot_gamma);\n')
+                of.write(f'{idnt}rate_eval.enuc_weak += C::Legacy::n_A * {self.symbol_rates.name_y}({r.reactants[0].cindex()}) * (edot_nu + edot_gamma);\n')
 
                 of.write('\n')
 
@@ -433,10 +433,12 @@ class BaseCxxNetwork(ABC, RateCollection):
 
         of.write("struct rate_t {\n")
         of.write("    Array1D<Real, 1, NumRates>  screened_rates;\n")
+        of.write("    Real enuc_weak;\n")
         of.write("};\n\n")
         of.write("struct rate_derivs_t {\n")
         of.write("    Array1D<Real, 1, NumRates>  screened_rates;\n")
         of.write("    Array1D<Real, 1, NumRates>  dscreened_rates_dT;\n")
+        of.write("    Real enuc_weak;\n")
         of.write("};\n\n")
 
     def _approx_rate_functions(self, n_indent, of):

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -341,7 +341,8 @@ class BaseCxxNetwork(ABC, RateCollection):
                 of.write(f'{idnt}    rate_eval.dscreened_rates_dT(k_{r.cname()}) = drate_dt;\n')
                 of.write(f'{idnt}}}\n')
 
-                of.write(f'{idnt}rate_eval.add_energy_rate(k_{r.cname()}) = edot_nu + edot_gamma;\n')
+                of.write(f'{idnt}enuc_weak += C::Legacy::n_A * {self.symbol_rates.name_y}({r.reactants[0].cindex()}) * (edot_nu + edot_gamma);\n')
+
                 of.write('\n')
 
     def _ydot(self, n_indent, of):
@@ -432,14 +433,10 @@ class BaseCxxNetwork(ABC, RateCollection):
 
         of.write("struct rate_t {\n")
         of.write("    Array1D<Real, 1, NumRates>  screened_rates;\n")
-        if len(self.tabular_rates) > 0:
-            of.write("    Array1D<Real, NrateReaclib+1, NrateReaclib+NrateTabular> add_energy_rate;\n")
         of.write("};\n\n")
         of.write("struct rate_derivs_t {\n")
         of.write("    Array1D<Real, 1, NumRates>  screened_rates;\n")
         of.write("    Array1D<Real, 1, NumRates>  dscreened_rates_dT;\n")
-        if len(self.tabular_rates) > 0:
-            of.write("    Array1D<Real, NrateReaclib+1, NrateReaclib+NrateTabular> add_energy_rate;\n")
         of.write("};\n\n")
 
     def _approx_rate_functions(self, n_indent, of):

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -185,6 +185,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     [[maybe_unused]] Real rate, drate_dt, edot_nu, edot_gamma;
 
+    rate_eval.enuc_weak = 0.0;
 
 }
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
+void evaluate_rates(const burn_t& state, T& rate_eval) {
 
 
     // create molar fractions
@@ -233,9 +233,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 
     constexpr int do_T_derivatives = 0;
 
-    Real enuc_weak{0.0};
-
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -245,7 +243,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     ener_gener_rate(ydot, enuc);
 
     // include any weak rate neutrino losses
-    enuc += enuc_weak;
+    enuc += rate_eval.enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -334,9 +332,8 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    Real enuc_weak{0.0};
 
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -187,6 +187,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     rate_eval.enuc_weak = 0.0;
 
+
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval) {
+void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
 
 
     // create molar fractions
@@ -232,7 +232,10 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     rate_t rate_eval;
 
     constexpr int do_T_derivatives = 0;
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
+
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -241,7 +244,8 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal) and gamma heating
+    // include any weak rate neutrino losses
+    enuc += enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -330,7 +334,9 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
@@ -13,11 +13,13 @@ using namespace Species;
 
 struct rate_t {
     Array1D<Real, 1, NumRates>  screened_rates;
+    Real enuc_weak;
 };
 
 struct rate_derivs_t {
     Array1D<Real, 1, NumRates>  screened_rates;
     Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Real enuc_weak;
 };
 
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
+void evaluate_rates(const burn_t& state, T& rate_eval) {
 
 
     // create molar fractions
@@ -187,9 +187,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 
     constexpr int do_T_derivatives = 0;
 
-    Real enuc_weak{0.0};
-
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -199,7 +197,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     ener_gener_rate(ydot, enuc);
 
     // include any weak rate neutrino losses
-    enuc += enuc_weak;
+    enuc += rate_eval.enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -321,9 +319,8 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    Real enuc_weak{0.0};
 
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -135,6 +135,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     rate_eval.enuc_weak = 0.0;
 
+
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval) {
+void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
 
 
     // create molar fractions
@@ -186,7 +186,10 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     rate_t rate_eval;
 
     constexpr int do_T_derivatives = 0;
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
+
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -195,7 +198,8 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal) and gamma heating
+    // include any weak rate neutrino losses
+    enuc += enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -317,7 +321,9 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -133,6 +133,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     [[maybe_unused]] Real rate, drate_dt, edot_nu, edot_gamma;
 
+    rate_eval.enuc_weak = 0.0;
 
 }
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
@@ -13,11 +13,13 @@ using namespace Species;
 
 struct rate_t {
     Array1D<Real, 1, NumRates>  screened_rates;
+    Real enuc_weak;
 };
 
 struct rate_derivs_t {
     Array1D<Real, 1, NumRates>  screened_rates;
     Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Real enuc_weak;
 };
 
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
+void evaluate_rates(const burn_t& state, T& rate_eval) {
 
 
     // create molar fractions
@@ -139,7 +139,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_na23_to_ne23) = drate_dt;
     }
-    enuc_weak += C::Legacy::n_A * Y(Na23) * (edot_nu + edot_gamma);
+    rate_eval.enuc_weak += C::Legacy::n_A * Y(Na23) * (edot_nu + edot_gamma);
 
     tabular_evaluate(j_ne23_na23_meta, j_ne23_na23_rhoy, j_ne23_na23_temp, j_ne23_na23_data,
                      rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);
@@ -147,7 +147,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_ne23_to_na23) = drate_dt;
     }
-    enuc_weak += C::Legacy::n_A * Y(Ne23) * (edot_nu + edot_gamma);
+    rate_eval.enuc_weak += C::Legacy::n_A * Y(Ne23) * (edot_nu + edot_gamma);
 
 
 }
@@ -217,9 +217,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 
     constexpr int do_T_derivatives = 0;
 
-    Real enuc_weak{0.0};
-
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -229,7 +227,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     ener_gener_rate(ydot, enuc);
 
     // include any weak rate neutrino losses
-    enuc += enuc_weak;
+    enuc += rate_eval.enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -327,9 +325,8 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    Real enuc_weak{0.0};
 
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -133,6 +133,8 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     [[maybe_unused]] Real rate, drate_dt, edot_nu, edot_gamma;
 
+    rate_eval.enuc_weak = 0.0;
+
     tabular_evaluate(j_na23_ne23_meta, j_na23_ne23_rhoy, j_na23_ne23_temp, j_na23_ne23_data,
                      rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_na23_to_ne23) = rate;

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval) {
+void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
 
 
     // create molar fractions
@@ -139,7 +139,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_na23_to_ne23) = drate_dt;
     }
-    rate_eval.add_energy_rate(k_na23_to_ne23) = edot_nu + edot_gamma;
+    enuc_weak += C::Legacy::n_A * Y(Na23) * (edot_nu + edot_gamma);
 
     tabular_evaluate(j_ne23_na23_meta, j_ne23_na23_rhoy, j_ne23_na23_temp, j_ne23_na23_data,
                      rhoy, state.T, rate, drate_dt, edot_nu, edot_gamma);
@@ -147,7 +147,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
     if constexpr (std::is_same<T, rate_derivs_t>::value) {
         rate_eval.dscreened_rates_dT(k_ne23_to_na23) = drate_dt;
     }
-    rate_eval.add_energy_rate(k_ne23_to_na23) = edot_nu + edot_gamma;
+    enuc_weak += C::Legacy::n_A * Y(Ne23) * (edot_nu + edot_gamma);
 
 
 }
@@ -216,7 +216,10 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     rate_t rate_eval;
 
     constexpr int do_T_derivatives = 0;
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
+
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -225,9 +228,8 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal) and gamma heating
-    enuc += C::Legacy::n_A * Y(Na23) * rate_eval.add_energy_rate(k_na23_to_ne23);
-    enuc += C::Legacy::n_A * Y(Ne23) * rate_eval.add_energy_rate(k_ne23_to_na23);
+    // include any weak rate neutrino losses
+    enuc += enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -325,7 +327,9 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/reaclib_rates.H
@@ -13,11 +13,13 @@ using namespace Species;
 
 struct rate_t {
     Array1D<Real, 1, NumRates>  screened_rates;
+    Real enuc_weak;
 };
 
 struct rate_derivs_t {
     Array1D<Real, 1, NumRates>  screened_rates;
     Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Real enuc_weak;
 };
 
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/reaclib_rates.H
@@ -13,13 +13,11 @@ using namespace Species;
 
 struct rate_t {
     Array1D<Real, 1, NumRates>  screened_rates;
-    Array1D<Real, NrateReaclib+1, NrateReaclib+NrateTabular> add_energy_rate;
 };
 
 struct rate_derivs_t {
     Array1D<Real, 1, NumRates>  screened_rates;
     Array1D<Real, 1, NumRates>  dscreened_rates_dT;
-    Array1D<Real, NrateReaclib+1, NrateReaclib+NrateTabular> add_energy_rate;
 };
 
 

--- a/pynucastro/networks/tests/_simple_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_simple_cxx_reference/reaclib_rates.H
@@ -11,11 +11,13 @@ using namespace Species;
 
 struct rate_t {
     Array1D<Real, 1, NumRates>  screened_rates;
+    Real enuc_weak;
 };
 
 struct rate_derivs_t {
     Array1D<Real, 1, NumRates>  screened_rates;
     Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Real enuc_weak;
 };
 
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
+void evaluate_rates(const burn_t& state, T& rate_eval) {
 
 
     // create molar fractions
@@ -119,9 +119,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 
     constexpr int do_T_derivatives = 0;
 
-    Real enuc_weak{0.0};
-
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -131,7 +129,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     ener_gener_rate(ydot, enuc);
 
     // include any weak rate neutrino losses
-    enuc += enuc_weak;
+    enuc += rate_eval.enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -179,9 +177,8 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    Real enuc_weak{0.0};
 
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
 
     // Species Jacobian elements with respect to other species
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -83,6 +83,8 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
 
     [[maybe_unused]] Real rate, drate_dt, edot_nu, edot_gamma;
 
+    rate_eval.enuc_weak = 0.0;
+
     <compute_tabular_rates>(1)
 
 }

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -43,7 +43,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void evaluate_rates(const burn_t& state, T& rate_eval) {
+void evaluate_rates(const burn_t& state, T& rate_eval, Real& enuc_weak) {
 
 
     // create molar fractions
@@ -118,7 +118,10 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     rate_t rate_eval;
 
     constexpr int do_T_derivatives = 0;
-    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
+
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval, enuc_weak);
 
     rhs_nuc(state, ydot, Y, rate_eval.screened_rates);
 
@@ -127,8 +130,8 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     Real enuc;
     ener_gener_rate(ydot, enuc);
 
-    // include reaction neutrino losses (non-thermal) and gamma heating
-    <enuc_add_energy_rate>(1)
+    // include any weak rate neutrino losses
+    enuc += enuc_weak;
 
     // Get the thermal neutrino losses
 
@@ -176,7 +179,9 @@ void actual_jac(const burn_t& state, MatrixType& jac)
     rate_derivs_t rate_eval;
 
     constexpr int do_T_derivatives = 1;
-    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval);
+    Real enuc_weak{0.0};
+
+    evaluate_rates<do_T_derivatives, rate_derivs_t>(state, rate_eval, enuc_weak);
 
     // Species Jacobian elements with respect to other species
 


### PR DESCRIPTION
now we just accumulate it together in a single term instead of storing each rate's contribution separately in an Array1D