### PR TITLE
Move pytest exclusions to pyproject.toml

### DIFF
--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -52,7 +52,7 @@ jobs:
           lscpu
 
       - name: Run tests with pytest
-        run: pytest -v -s --nbval --cov=pynucastro --ignore=docs --ignore-glob="pynucastro/library/tabular/*.ipynb" --ignore=examples/rxn-network-integration.ipynb --ignore=examples/o16o16_rates.ipynb
+        run: pytest -v -s --nbval --cov=pynucastro
 
       - name: Upload output from failed write_network tests
         uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,11 @@ skip = ".git,*docs/build,*.bib"
 [tool.isort]
 known_first_party = ["pynucastro"]
 skip = ["pynucastro/networks/tests/_python_reference/network.py"]
+
+[tool.pytest.ini_options]
+addopts = """\
+  --ignore=docs \
+  --ignore-glob=pynucastro/library/tabular/*.ipynb \
+  --ignore=examples/rxn-network-integration.ipynb \
+  --ignore=examples/o16o16_rates.ipynb \
+  """


### PR DESCRIPTION
This lets us run pytest locally without having to pass all the `--ignore` options.