### PR TITLE
for Library.get_rate_by_name we return None if any names don't exist

### DIFF
--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -324,7 +324,7 @@ class Library:
 
         if len(rates_out) == 0:
             return None
-        elif len(rates_out) == 1:
+        if len(rates_out) == 1:
             return rates_out[0]
         return rates_out
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -318,7 +318,8 @@ class Library:
             rf = RateFilter(reactants=reactants, products=products)
             _lib = self.filter(rf)
             if _lib is None:
-                return None
+                print(f"rate {rname} not found")
+                continue
             rates_out += _lib.get_rates()
 
         if (len(rates_out)) == 1:

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -322,7 +322,9 @@ class Library:
                 continue
             rates_out += _lib.get_rates()
 
-        if (len(rates_out)) == 1:
+        if len(rates_out) == 0:
+            return None
+        elif len(rates_out) == 1:
             return rates_out[0]
         return rates_out
 


### PR DESCRIPTION
we were bailing out of the search early.  Now we print a message and continue on to the next rate in the list.  This way we still return a list of rates even if one of the names doesn't exist.