### PR TITLE
Reorganize requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,25 @@
-networkx>=2.1
-scipy>=1.0.0
-numpy>=1.13.3,<2.0
-sympy>=1.1.1
-matplotlib>=2.1.0
-jupyter>=1.0.0
+# runtime dependencies
 ipywidgets>=7.1.2
-sphinx_rtd_theme>=1.1.0
-Sphinx
-nbsphinx>=0.3.1
-pytest>=3.6
-nbval>=0.9.0
+matplotlib>=2.1.0
+networkx>=2.1
+numpy>=1.13.3,<2.0
+scipy>=1.0.0
+sympy>=1.1.1
+
+# optional dependencies
 numba>=0.52
+
+# tests
+nbval>=0.9.0
 pytest-cov>=2.6.0
-setuptools_scm>=8
+pytest>=3.6
+
+# docs
+ipykernel
 jinja2==3.0.3
+nbsphinx>=0.3.1
+Sphinx
+sphinx-copybutton
 sphinx-mdinclude
 sphinx-prompt
-sphinx-copybutton
+sphinx_rtd_theme>=1.1.0


### PR DESCRIPTION
Group packages by what they're needed for, and sort each group alphabetically.

This also replaces the `jupyter` requirement with `ipykernel`, as building the docs doesn't need the entire jupyter infrastructure.