### PR TITLE
make the docs on evaluate_rates() clearer

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -927,11 +927,13 @@ class RateCollection:
 
         Note: this returns that rate as dY/dt, where Y is the molar fraction.
         For a 2 body reaction, a + b, this will be of the form:
+
            rho Y_a Y_b N_A <sigma v> / (1 + delta_{ab}
+
         where delta is the Kronecker delta that accounts for a = b.
 
         If you want dn/dt, where n is the number density (so you get
-        n_a n_b <sigma v>), then you need to multiple the results here
+        n_a n_b <sigma v>), then you need to multiply the results here
         by rho N_A (where N_A is Avogadro's number).
         """
         rvals = {}

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -928,7 +928,7 @@ class RateCollection:
         Note: this returns that rate as dY/dt, where Y is the molar fraction.
         For a 2 body reaction, a + b, this will be of the form:
 
-           rho Y_a Y_b N_A <sigma v> / (1 + delta_{ab}
+        rho Y_a Y_b N_A <sigma v> / (1 + delta_{ab}
 
         where delta is the Kronecker delta that accounts for a = b.
 

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -923,7 +923,17 @@ class RateCollection:
 
     def evaluate_rates(self, rho, T, composition, screen_func=None):
         """evaluate the rates for a specific density, temperature, and
-        composition, with optional screening"""
+        composition, with optional screening
+
+        Note: this returns that rate as dY/dt, where Y is the molar fraction.
+        For a 2 body reaction, a + b, this will be of the form:
+           rho Y_a Y_b N_A <sigma v> / (1 + delta_{ab}
+        where delta is the Kronecker delta that accounts for a = b.
+
+        If you want dn/dt, where n is the number density (so you get
+        n_a n_b <sigma v>), then you need to multiple the results here
+        by rho N_A (where N_A is Avogadro's number).
+        """
         rvals = {}
         ys = composition.get_molar()
         y_e = composition.eval_ye()


### PR DESCRIPTION
we are returning dY/dt but a user might expect r = n_A n_B <sigma v>