### PR TITLE
Update Microphysics benchmarks after sneut5 sin/cos fix

### DIFF
--- a/.github/workflows/microphysics-benchmarks/ase_nse_net_unit_test.out
+++ b/.github/workflows/microphysics-benchmarks/ase_nse_net_unit_test.out
@@ -1,4 +1,5 @@
-AMReX (23.08-120-g579df318ce0d) initialized
+Initializing AMReX (23.11-4-ga7afcba3cffd)...
+AMReX (23.11-4-ga7afcba3cffd) initialized
 starting the single zone burn...
 reading in network electron-capture / beta-decay tables...
 chemical potential of proton is -3
@@ -31,4 +32,4 @@ Cr48 : 0.009959852831
 Fe52 : 0.05964589202
 Ni56 : 0.2350269888
 We're in NSE. 
-AMReX (23.08-120-g579df318ce0d) finalized
+AMReX (23.11-4-ga7afcba3cffd) finalized

--- a/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
+++ b/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
@@ -1,4 +1,5 @@
-AMReX (23.08-120-g579df318ce0d) initialized
+Initializing AMReX (23.11-4-ga7afcba3cffd)...
+AMReX (23.11-4-ga7afcba3cffd) initialized
 starting the single zone burn...
 reading in network electron-capture / beta-decay tables...
 Maximum Time (s): 0.01
@@ -29,37 +30,37 @@ RHS at t = 0
    S32 1323519.174
 ------------------------------------
 successful? 1
- - Hnuc = 4.555404693e+19
- - added e = 4.555404693e+17
- - final T = 6735967493
+ - Hnuc = 4.111466233e+19
+ - added e = 4.111466233e+17
+ - final T = 6536235789
 ------------------------------------
 e initial = 5.995956082e+17
-e final =   1.055136077e+18
+e final =   1.010742231e+18
 ------------------------------------
 new mass fractions: 
-H1 0.008595815549
-He4 4.152700815e-13
-O16 6.210300397e-07
-O20 0.009741776606
-F20 0.009740438851
-Ne20 9.999999868e-31
-Mg24 4.491783724e-09
-Al27 7.648139704e-21
-Si28 0.2708503134
-P31 8.806134354e-14
-S32 0.7010710301
+H1 0.007813581548
+He4 9.986703417e-31
+O16 7.812412175e-07
+O20 0.009524501615
+F20 0.00952319448
+Ne20 9.986703417e-31
+Mg24 8.489446236e-12
+Al27 9.986703417e-31
+Si28 0.2115906158
+P31 9.986703417e-31
+S32 0.7615473253
 ------------------------------------
 species creation rates: 
-omegadot(H1): -0.1404184451
+omegadot(H1): -0.2186418452
 omegadot(He4): -3
-omegadot(O16): -49.9999379
-omegadot(O20): -0.02582233936
-omegadot(F20): -0.02595611491
+omegadot(O16): -49.99992188
+omegadot(O20): -0.04754983851
+omegadot(F20): -0.04768055199
 omegadot(Ne20): -30
-omegadot(Mg24): -9.999999551
+omegadot(Mg24): -9.999999999
 omegadot(Al27): -1
-omegadot(Si28): 26.08503134
+omegadot(Si28): 20.15906158
 omegadot(P31): -1
-omegadot(S32): 69.10710301
-number of steps taken: 22812
-AMReX (23.08-120-g579df318ce0d) finalized
+omegadot(S32): 75.15473253
+number of steps taken: 9639
+AMReX (23.11-4-ga7afcba3cffd) finalized

--- a/.github/workflows/microphysics-benchmarks/subch_approx_unit_test.out
+++ b/.github/workflows/microphysics-benchmarks/subch_approx_unit_test.out
@@ -1,4 +1,5 @@
-AMReX (23.08-120-g579df318ce0d) initialized
+Initializing AMReX (23.11-4-ga7afcba3cffd)...
+AMReX (23.11-4-ga7afcba3cffd) initialized
 starting the single zone burn...
 reading in network electron-capture / beta-decay tables...
 Maximum Time (s): 1e-05
@@ -51,59 +52,59 @@ RHS at t = 0
   Ni56 2.574225196e-29
 ------------------------------------
 successful? 1
- - Hnuc = 7.242795607e+22
- - added e = 7.242795607e+17
- - final T = 3332749137
+ - Hnuc = 7.242504668e+22
+ - added e = 7.242504668e+17
+ - final T = 3332738253
 ------------------------------------
 e initial = 1.396711859e+18
-e final =   2.12099142e+18
+e final =   2.120962326e+18
 ------------------------------------
 new mass fractions: 
-H1 0.1076931417
-He4 0.08271029045
-C12 1.784869828e-05
-N13 3.39288153e-08
-N14 3.299674554e-07
-O16 0.1086428974
-F18 1.41735561e-07
-Ne20 0.007004116589
-Ne21 5.733659437e-06
-Na22 0.1571361627
-Na23 4.823302158e-07
-Mg24 0.00445536025
-Al27 6.197224432e-06
-Si28 0.06147398898
-P31 9.544436584e-06
-S32 0.1151631603
-Ar36 0.0989622079
-Ca40 0.2507752683
-Ti44 0.005263479859
-Cr48 0.0006666468945
-Fe52 1.291933247e-05
-Ni56 4.7290363e-08
+H1 0.1076931392
+He4 0.08271604755
+C12 1.784659301e-05
+N13 3.392571632e-08
+N14 3.299221207e-07
+O16 0.108645045
+F18 1.417109763e-07
+Ne20 0.007004350626
+Ne21 5.73319595e-06
+Na22 0.1571361633
+Na23 4.823680511e-07
+Mg24 0.004455549374
+Al27 6.197826902e-06
+Si28 0.06147651501
+P31 9.545310692e-06
+S32 0.1151668114
+Ar36 0.09896332458
+Ca40 0.2507603092
+Ti44 0.005262916908
+Cr48 0.0006665524196
+Fe52 1.291730016e-05
+Ni56 4.728298219e-08
 ------------------------------------
 species creation rates: 
-omegadot(H1): 769.3141707
-omegadot(He4): -41728.97096
-omegadot(C12): -9998.21513
+omegadot(H1): 769.3139202
+omegadot(He4): -41728.39524
+omegadot(C12): -9998.215341
 omegadot(N13): -9999.996607
-omegadot(N14): -9999.967003
-omegadot(O16): 864.289744
-omegadot(F18): 0.0141735561
-omegadot(Ne20): 700.4116589
-omegadot(Ne21): 0.5733659437
-omegadot(Na22): 15713.61627
-omegadot(Na23): 0.04823302158
-omegadot(Mg24): 445.536025
-omegadot(Al27): 0.6197224432
-omegadot(Si28): 6147.398898
-omegadot(P31): 0.9544436584
-omegadot(S32): 11516.31603
-omegadot(Ar36): 9896.22079
-omegadot(Ca40): 25077.52683
-omegadot(Ti44): 526.3479859
-omegadot(Cr48): 66.66468945
-omegadot(Fe52): 1.291933247
-omegadot(Ni56): 0.0047290363
-number of steps taken: 544
-AMReX (23.08-120-g579df318ce0d) finalized
+omegadot(N14): -9999.967008
+omegadot(O16): 864.5045001
+omegadot(F18): 0.01417109763
+omegadot(Ne20): 700.4350626
+omegadot(Ne21): 0.573319595
+omegadot(Na22): 15713.61633
+omegadot(Na23): 0.04823680511
+omegadot(Mg24): 445.5549374
+omegadot(Al27): 0.6197826902
+omegadot(Si28): 6147.651501
+omegadot(P31): 0.9545310692
+omegadot(S32): 11516.68114
+omegadot(Ar36): 9896.332458
+omegadot(Ca40): 25076.03092
+omegadot(Ti44): 526.2916908
+omegadot(Cr48): 66.65524196
+omegadot(Fe52): 1.291730016
+omegadot(Ni56): 0.004728298219
+number of steps taken: 594
+AMReX (23.11-4-ga7afcba3cffd) finalized


### PR DESCRIPTION
See AMReX-Astro/Microphysics#1380.

The subch_approx benchmark now matches the version before #677, but the ECSN one has changed (which matches what we saw with the benchmarks in Microphysics).