### PR TITLE
Allow manually triggering Github Actions tests

### DIFF
--- a/.github/workflows/cxx-network.yml
+++ b/.github/workflows/cxx-network.yml
@@ -1,6 +1,6 @@
 name: C++ network
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   compilation:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   flake8:

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   isort:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   pylint:

--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - development
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/simple-cxx-network.yml
+++ b/.github/workflows/simple-cxx-network.yml
@@ -1,6 +1,6 @@
 name: Simple C++ network
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   compilation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add the `workflow_dispatch` event to the test workflows, so we can run tests on a specific branch without needing to make a PR.