### PR TITLE
Enable color output in the pytest workflow

### DIFF
--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -45,7 +45,7 @@ jobs:
           lscpu
 
       - name: Run tests with pytest
-        run: pytest -v -s --nbval --cov=pynucastro
+        run: pytest -v -s --nbval --cov=pynucastro --color=yes
 
       - name: Upload output from failed write_network tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This makes it a lot easier to spot failing tests, and adds syntax highlighting to the tracebacks.