### PR TITLE
don't lint the missing default branch for spin switch

### DIFF
--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
@@ -95,7 +95,7 @@ constexpr amrex::Real get_spin_state(const int inuc) {
 
     amrex::Real spin = -1.0;
 
-    switch (inuc) {
+    switch (inuc) {  // NOLINT(bugprone-switch-missing-default-case)
 
     case He4:
     case Mg24:

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
@@ -190,7 +190,7 @@ constexpr amrex::Real get_spin_state(const int inuc) {
 
     amrex::Real spin = -1.0;
 
-    switch (inuc) {
+    switch (inuc) {  // NOLINT(bugprone-switch-missing-default-case)
 
     case He4:
     case Fe52:

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
@@ -95,7 +95,7 @@ constexpr amrex::Real get_spin_state(const int inuc) {
 
     amrex::Real spin = -1.0;
 
-    switch (inuc) {
+    switch (inuc) {  // NOLINT(bugprone-switch-missing-default-case)
 
     case He4:
     case C12:

--- a/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
@@ -97,7 +97,7 @@ constexpr amrex::Real get_spin_state(const int inuc) {
 
     amrex::Real spin = -1.0;
 
-    switch (inuc) {
+    switch (inuc) {  // NOLINT(bugprone-switch-missing-default-case)
 
     <spin_state_cases>(1)
 


### PR DESCRIPTION
this mutes a clang-tidy warning