### PR TITLE
Cache partition function interpolation in C++

### DIFF
--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
@@ -66,6 +66,14 @@ namespace part_fun {
 
     }
 
+    struct pf_cache_t {
+        // Store the coefficient and derivative adjacent in memory, as they're
+        // always accessed at the same time.
+        // The entries will be default-initialized to zero, which is fine since
+        // log10(x) is never zero.
+        amrex::Array2D<amrex::Real, 1, NumSpecTotal, 1, 2, Order::C> data{};
+    };
+
 }
 
 // main interface
@@ -86,6 +94,22 @@ void get_partition_function(const int inuc, [[maybe_unused]] const tf_t& tfactor
 
     }
 
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void get_partition_function_cached(const int inuc, const tf_t& tfactors,
+                                   part_fun::pf_cache_t& pf_cache,
+                                   amrex::Real& pf, amrex::Real& dpf_dT) {
+    if (pf_cache.data(inuc, 1) != 0.0_rt) {
+        // present in cache
+        amrex::ignore_unused(tfactors);
+        pf = pf_cache.data(inuc, 1);
+        dpf_dT = pf_cache.data(inuc, 2);
+    } else {
+        get_partition_function(inuc, tfactors, pf, dpf_dT);
+        pf_cache.data(inuc, 1) = pf;
+        pf_cache.data(inuc, 2) = dpf_dT;
+    }
 }
 
 // spins

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
@@ -149,6 +149,14 @@ namespace part_fun {
 
     }
 
+    struct pf_cache_t {
+        // Store the coefficient and derivative adjacent in memory, as they're
+        // always accessed at the same time.
+        // The entries will be default-initialized to zero, which is fine since
+        // log10(x) is never zero.
+        amrex::Array2D<amrex::Real, 1, NumSpecTotal, 1, 2, Order::C> data{};
+    };
+
 }
 
 // main interface
@@ -181,6 +189,22 @@ void get_partition_function(const int inuc, [[maybe_unused]] const tf_t& tfactor
 
     }
 
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void get_partition_function_cached(const int inuc, const tf_t& tfactors,
+                                   part_fun::pf_cache_t& pf_cache,
+                                   amrex::Real& pf, amrex::Real& dpf_dT) {
+    if (pf_cache.data(inuc, 1) != 0.0_rt) {
+        // present in cache
+        amrex::ignore_unused(tfactors);
+        pf = pf_cache.data(inuc, 1);
+        dpf_dT = pf_cache.data(inuc, 2);
+    } else {
+        get_partition_function(inuc, tfactors, pf, dpf_dT);
+        pf_cache.data(inuc, 1) = pf;
+        pf_cache.data(inuc, 2) = dpf_dT;
+    }
 }
 
 // spins

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
@@ -121,7 +121,7 @@ void rate_He4_Fe52_to_p_Co55(const tf_t& tfactors, amrex::Real& rate, amrex::Rea
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_Ni56_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT) {
+void rate_Ni56_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT, [[maybe_unused]] part_fun::pf_cache_t& pf_cache) {
 
     // Ni56 --> He4 + Fe52
 
@@ -152,7 +152,7 @@ void rate_Ni56_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amre
 
     amrex::Real Ni56_pf, dNi56_pf_dT;
     // interpolating Ni56 partition function
-    get_partition_function(Ni56, tfactors, Ni56_pf, dNi56_pf_dT);
+    get_partition_function_cached(Ni56, tfactors, pf_cache, Ni56_pf, dNi56_pf_dT);
 
     amrex::Real He4_pf, dHe4_pf_dT;
     // setting He4 partition function to 1.0 by default, independent of T
@@ -161,7 +161,7 @@ void rate_Ni56_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amre
 
     amrex::Real Fe52_pf, dFe52_pf_dT;
     // interpolating Fe52 partition function
-    get_partition_function(Fe52, tfactors, Fe52_pf, dFe52_pf_dT);
+    get_partition_function_cached(Fe52, tfactors, pf_cache, Fe52_pf, dFe52_pf_dT);
 
     amrex::Real z_r = He4_pf * Fe52_pf;
     amrex::Real z_p = Ni56_pf;
@@ -178,7 +178,7 @@ void rate_Ni56_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amre
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_Ni56_to_p_Co55_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT) {
+void rate_Ni56_to_p_Co55_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT, [[maybe_unused]] part_fun::pf_cache_t& pf_cache) {
 
     // Ni56 --> p + Co55
 
@@ -209,7 +209,7 @@ void rate_Ni56_to_p_Co55_derived(const tf_t& tfactors, amrex::Real& rate, amrex:
 
     amrex::Real Ni56_pf, dNi56_pf_dT;
     // interpolating Ni56 partition function
-    get_partition_function(Ni56, tfactors, Ni56_pf, dNi56_pf_dT);
+    get_partition_function_cached(Ni56, tfactors, pf_cache, Ni56_pf, dNi56_pf_dT);
 
     amrex::Real p_pf, dp_pf_dT;
     // setting p partition function to 1.0 by default, independent of T
@@ -218,7 +218,7 @@ void rate_Ni56_to_p_Co55_derived(const tf_t& tfactors, amrex::Real& rate, amrex:
 
     amrex::Real Co55_pf, dCo55_pf_dT;
     // interpolating Co55 partition function
-    get_partition_function(Co55, tfactors, Co55_pf, dCo55_pf_dT);
+    get_partition_function_cached(Co55, tfactors, pf_cache, Co55_pf, dCo55_pf_dT);
 
     amrex::Real z_r = p_pf * Co55_pf;
     amrex::Real z_p = Ni56_pf;
@@ -235,7 +235,7 @@ void rate_Ni56_to_p_Co55_derived(const tf_t& tfactors, amrex::Real& rate, amrex:
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_p_Co55_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT) {
+void rate_p_Co55_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, amrex::Real& drate_dT, [[maybe_unused]] part_fun::pf_cache_t& pf_cache) {
 
     // Co55 + p --> He4 + Fe52
 
@@ -276,11 +276,11 @@ void rate_p_Co55_to_He4_Fe52_derived(const tf_t& tfactors, amrex::Real& rate, am
 
     amrex::Real Co55_pf, dCo55_pf_dT;
     // interpolating Co55 partition function
-    get_partition_function(Co55, tfactors, Co55_pf, dCo55_pf_dT);
+    get_partition_function_cached(Co55, tfactors, pf_cache, Co55_pf, dCo55_pf_dT);
 
     amrex::Real Fe52_pf, dFe52_pf_dT;
     // interpolating Fe52 partition function
-    get_partition_function(Fe52, tfactors, Fe52_pf, dFe52_pf_dT);
+    get_partition_function_cached(Fe52, tfactors, pf_cache, Fe52_pf, dFe52_pf_dT);
 
     amrex::Real z_r = He4_pf * Fe52_pf;
     amrex::Real z_p = p_pf * Co55_pf;
@@ -306,6 +306,8 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
     amrex::Real rate;
     amrex::Real drate_dT;
 
+    part_fun::pf_cache_t pf_cache{};
+
     rate_He4_Fe52_to_Ni56<do_T_derivatives>(tfactors, rate, drate_dT);
     rate_eval.screened_rates(k_He4_Fe52_to_Ni56) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
@@ -324,19 +326,19 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
         rate_eval.dscreened_rates_dT(k_He4_Fe52_to_p_Co55) = drate_dT;
 
     }
-    rate_Ni56_to_He4_Fe52_derived<do_T_derivatives>(tfactors, rate, drate_dT);
+    rate_Ni56_to_He4_Fe52_derived<do_T_derivatives>(tfactors, rate, drate_dT, pf_cache);
     rate_eval.screened_rates(k_Ni56_to_He4_Fe52_derived) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
         rate_eval.dscreened_rates_dT(k_Ni56_to_He4_Fe52_derived) = drate_dT;
 
     }
-    rate_Ni56_to_p_Co55_derived<do_T_derivatives>(tfactors, rate, drate_dT);
+    rate_Ni56_to_p_Co55_derived<do_T_derivatives>(tfactors, rate, drate_dT, pf_cache);
     rate_eval.screened_rates(k_Ni56_to_p_Co55_derived) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
         rate_eval.dscreened_rates_dT(k_Ni56_to_p_Co55_derived) = drate_dT;
 
     }
-    rate_p_Co55_to_He4_Fe52_derived<do_T_derivatives>(tfactors, rate, drate_dT);
+    rate_p_Co55_to_He4_Fe52_derived<do_T_derivatives>(tfactors, rate, drate_dT, pf_cache);
     rate_eval.screened_rates(k_p_Co55_to_He4_Fe52_derived) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
         rate_eval.dscreened_rates_dT(k_p_Co55_to_He4_Fe52_derived) = drate_dT;

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
@@ -66,6 +66,14 @@ namespace part_fun {
 
     }
 
+    struct pf_cache_t {
+        // Store the coefficient and derivative adjacent in memory, as they're
+        // always accessed at the same time.
+        // The entries will be default-initialized to zero, which is fine since
+        // log10(x) is never zero.
+        amrex::Array2D<amrex::Real, 1, NumSpecTotal, 1, 2, Order::C> data{};
+    };
+
 }
 
 // main interface
@@ -86,6 +94,22 @@ void get_partition_function(const int inuc, [[maybe_unused]] const tf_t& tfactor
 
     }
 
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void get_partition_function_cached(const int inuc, const tf_t& tfactors,
+                                   part_fun::pf_cache_t& pf_cache,
+                                   amrex::Real& pf, amrex::Real& dpf_dT) {
+    if (pf_cache.data(inuc, 1) != 0.0_rt) {
+        // present in cache
+        amrex::ignore_unused(tfactors);
+        pf = pf_cache.data(inuc, 1);
+        dpf_dT = pf_cache.data(inuc, 2);
+    } else {
+        get_partition_function(inuc, tfactors, pf, dpf_dT);
+        pf_cache.data(inuc, 1) = pf;
+        pf_cache.data(inuc, 2) = dpf_dT;
+    }
 }
 
 // spins

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -1838,7 +1838,7 @@ class DerivedRate(ReacLibRate):
 
         return fstring
 
-    def function_string_cxx(self, dtype="double", specifiers="inline", leave_open=False):
+    def function_string_cxx(self, dtype="double", specifiers="inline", leave_open=False, extra_args=()):
         """
         Return a string containing C++ function that computes the
         rate
@@ -1846,7 +1846,7 @@ class DerivedRate(ReacLibRate):
 
         self._warn_about_missing_pf_tables()
 
-        extra_args = ["[[maybe_unused]] part_fun::pf_cache_t& pf_cache"]
+        extra_args = ["[[maybe_unused]] part_fun::pf_cache_t& pf_cache", *extra_args]
         fstring = super().function_string_cxx(dtype=dtype, specifiers=specifiers, leave_open=True, extra_args=extra_args)
 
         # right now we have rate and drate_dT without the partition function
@@ -2122,7 +2122,7 @@ class ApproximateRate(ReacLibRate):
         string += f"    rate_eval.{self.fname} = rate\n\n"
         return string
 
-    def function_string_cxx(self, dtype="double", specifiers="inline", leave_open=False):
+    def function_string_cxx(self, dtype="double", specifiers="inline", leave_open=False, extra_args=()):
         """
         Return a string containing C++ function that computes the
         approximate rate
@@ -2131,10 +2131,11 @@ class ApproximateRate(ReacLibRate):
         if self.approx_type != "ap_pg":
             raise NotImplementedError("don't know how to work with this approximation")
 
+        args = ["const T& rate_eval", f"{dtype}& rate", f"{dtype}& drate_dT", *extra_args]
         fstring = ""
         fstring = "template <typename T>\n"
         fstring += f"{specifiers}\n"
-        fstring += f"void rate_{self.cname()}(const T& rate_eval, {dtype}& rate, {dtype}& drate_dT) {{\n\n"
+        fstring += f"void rate_{self.cname()}({', '.join(args)}) {{\n\n"
 
         if not self.is_reverse:
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
@@ -67,6 +67,14 @@ namespace part_fun {
 
     }
 
+    struct pf_cache_t {
+        // Store the coefficient and derivative adjacent in memory, as they're
+        // always accessed at the same time.
+        // The entries will be default-initialized to zero, which is fine since
+        // log10(x) is never zero.
+        amrex::Array2D<amrex::Real, 1, NumSpecTotal, 1, 2, Order::C> data{};
+    };
+
 }
 
 // main interface
@@ -88,6 +96,22 @@ void get_partition_function(const int inuc, [[maybe_unused]] const tf_t& tfactor
 
     }
 
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void get_partition_function_cached(const int inuc, const tf_t& tfactors,
+                                   part_fun::pf_cache_t& pf_cache,
+                                   amrex::Real& pf, amrex::Real& dpf_dT) {
+    if (pf_cache.data(inuc, 1) != 0.0_rt) {
+        // present in cache
+        amrex::ignore_unused(tfactors);
+        pf = pf_cache.data(inuc, 1);
+        dpf_dT = pf_cache.data(inuc, 2);
+    } else {
+        get_partition_function(inuc, tfactors, pf, dpf_dT);
+        pf_cache.data(inuc, 1) = pf;
+        pf_cache.data(inuc, 2) = dpf_dT;
+    }
 }
 
 // spins


### PR DESCRIPTION
The partition function interpolation for derived rates is performed multiple times for most of the nuclei within `fill_reaclib_rates()`. This stores the interpolation results in a cache in that function so they can be reused by other rates, which gives a 10-15% overall speedup in my tests with subch_base.