### PR TITLE
Address new pylint 3.2.0 warnings

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pylint
+          pip install 'pylint>=3.2.0'
 
       - name: Install pynucastro
         run: pip install .
 
       - name: Validate
-        run: pylint pynucastro pynucastro/**/tests
+        run: pylint --output-format=github pynucastro pynucastro/**/tests

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1060,6 +1060,7 @@ class RateCollection:
                 # if we are doing symmetric screening
                 for r in scr.rates:
                     # use scor from the previous loop iteration
+                    # pylint: disable-next=possibly-used-before-assignment
                     factors[r] = scor * scor2
             else:
                 # there might be several rates that have the same

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1867,7 +1867,7 @@ class RateCollection:
 
         # Get figure, colormap
         fig, ax = plt.subplots()
-        cmap = mpl.cm.get_cmap(cmap)
+        cmap = mpl.colormaps.get_cmap(cmap)  # pylint: disable=no-member
 
         # Get nuclei and all 3 numbers
         nuclei = self.unique_nuclei

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1643,7 +1643,6 @@ class RateCollection:
 
         valid_max = np.abs(jac).max()
 
-        # pylint: disable-next=redundant-keyword-arg
         norm = SymLogNorm(valid_max/rate_scaling, vmin=-valid_max, vmax=valid_max)
 
         fig, ax = plt.subplots()
@@ -1689,7 +1688,6 @@ class RateCollection:
         _ydot = np.asarray(_ydot)
         valid_max = np.abs(_ydot[_ydot != 0]).max()
 
-        # pylint: disable-next=redundant-keyword-arg
         norm = SymLogNorm(valid_max/1.e15, vmin=-valid_max, vmax=valid_max)
 
         # if there are a lot of rates, we split the network chart into

--- a/pynucastro/neutrino_cooling/sneut5.py
+++ b/pynucastro/neutrino_cooling/sneut5.py
@@ -734,6 +734,7 @@ def sneut5(rho, T, comp=None, *, abar=None, zbar=None,
 
         zeta = 1.579e5 * zbar * zbar * tempi
 
+        # pylint: disable-next=possibly-used-before-assignment
         c00 = 1.0 / (1.0 + f1 * nu + f2 * nu2 + f3 * nu3)
         dum = zeta * c00
 
@@ -743,6 +744,7 @@ def sneut5(rho, T, comp=None, *, abar=None, zbar=None,
         c00 = a1 * z + a2 * dd00 + a3 * dd01
 
         z = np.exp(c * nu)
+        # pylint: disable-next=possibly-used-before-assignment
         dd00 = b * z * (1.0 + d * dum)
         gum = 1.0 + dd00
 


### PR DESCRIPTION
Also use the new GitHub output formatting, so we can see the annotations in context in the "Files changed" tab (for example, [`bd42732` (#733)](https://github.com/pynucastro/pynucastro/pull/733/commits/bd427326b66c26f1c77961a688e31c8a14742cd0)).