### PR TITLE
Print all installed packages in the pytest CI

### DIFF
--- a/.github/workflows/pytest-all.yml
+++ b/.github/workflows/pytest-all.yml
@@ -39,10 +39,16 @@ jobs:
 
       - name: Print system info
         run: |
+          echo '::group::NumPy'
           pip install threadpoolctl &>/dev/null
           python -c "import sys, numpy; print(numpy.__version__); print(sys.version); print(numpy.show_runtime())"
-          echo
+          echo '::endgroup::'
+          echo '::group::CPU info'
           lscpu
+          echo '::endgroup::'
+          echo '::group::Package versions'
+          pip list --format=freeze
+          echo '::endgroup::'
 
       - name: Run tests with pytest
         run: pytest -v -s --nbval --cov=pynucastro --color=yes


### PR DESCRIPTION
This makes it much easier to compare package versions between runs to see if an update is causing any failures, rather than having to trawl through the install logs.