### PR TITLE
Relax numba version constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ scipy>=1.0.0
 sympy>=1.1.1
 
 # optional dependencies
-numba>=0.59
-llvmlite>=0.42.0rc1
+numba>=0.52
 
 # tests
 nbval>=0.9.0


### PR DESCRIPTION
This was originally updated for Python 3.12, but pip should be able to get compatible versions on its own.