### PR TITLE
Explicitly return a float from SingleSet.f()()

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -208,13 +208,13 @@ class SingleSet:
     def f(self):
         """ return a function for rate(tf) where tf is a Tfactors
         object """
-        return lambda tf: np.exp(self.a[0] +
-                                 self.a[1]*tf.T9i +
-                                 self.a[2]*tf.T913i +
-                                 self.a[3]*tf.T913 +
-                                 self.a[4]*tf.T9 +
-                                 self.a[5]*tf.T953 +
-                                 self.a[6]*tf.lnT9)
+        return lambda tf: float(np.exp(self.a[0] +
+                                       self.a[1]*tf.T9i +
+                                       self.a[2]*tf.T913i +
+                                       self.a[3]*tf.T913 +
+                                       self.a[4]*tf.T9 +
+                                       self.a[5]*tf.T953 +
+                                       self.a[6]*tf.lnT9))
 
     def dfdT(self):
         """ return a function for this dratedT(tf), where tf is a


### PR DESCRIPTION
As of numpy 2.0, the `repr()` of scalars includes the type information, which shows up in various places in interactive usage and Jupyter notebooks. Casting the result of SingleSet evaluation to a standard Python float avoids this entirely.