### PR TITLE
Cast the result of PartitionFunction.eval to a float

### DIFF
--- a/docs/source/nucleus.ipynb
+++ b/docs/source/nucleus.ipynb
@@ -136,7 +136,7 @@
     {
      "data": {
       "text/plain": [
-       "np.float64(1.002103)"
+       "1.002103"
       ]
      },
      "execution_count": 5,

--- a/pynucastro/nucdata/partition_function.py
+++ b/pynucastro/nucdata/partition_function.py
@@ -120,7 +120,8 @@ class PartitionFunction:
         except ValueError:
             print("invalid temperature")
             raise
-        return 10**self._interpolant(T, ext='const')  # extrapolates keeping the boundaries fixed.
+        # extrapolates keeping the boundaries fixed.
+        return float(10**self._interpolant(T, ext='const'))
 
 
 class PartitionFunctionTable:


### PR DESCRIPTION
Fixes test failure with numpy < 2.0.