### PR TITLE
ubuntu-latest now sometimes points to ubuntu-22.04 causing roundoff

### DIFF
--- a/.github/workflows/cxx-network.yml
+++ b/.github/workflows/cxx-network.yml
@@ -3,7 +3,7 @@ name: C++ network
 on: [pull_request, workflow_dispatch]
 jobs:
   compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fortran-network.yml
+++ b/.github/workflows/fortran-network.yml
@@ -3,7 +3,7 @@ name: Fortran network
 on: [pull_request, workflow_dispatch]
 jobs:
   compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/simple-cxx-network.yml
+++ b/.github/workflows/simple-cxx-network.yml
@@ -3,7 +3,7 @@ name: Simple C++ network
 on: [pull_request, workflow_dispatch]
 jobs:
   compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
for the C++/Fortran nets, it is likely the compiler diffs are the cause.  This pins to 22.04 until we make the comparison more robust to roundoff