### PR TITLE
disable matplotloib warnings in RateCollection

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -30,6 +30,7 @@ from pynucastro.screening import (get_screening_map, make_plasma_state,
                                   make_screen_factors)
 
 mpl.rcParams['figure.dpi'] = 100
+mpl.set_loglevel("error")
 
 
 class RateDuplicationError(Exception):


### PR DESCRIPTION
in matplotlib 3.10, some new warnings were introduced, but they are not really helpful.  This will still report errors and critical. Internally, matplotlib uses the python logger module, and this modifies that behavior.