### PR TITLE
don't set the RateCollection.plot() limits explicitly

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1728,9 +1728,6 @@ class RateCollection:
             else:
                 plt.colorbar(pc, ax=ax, label="log10(rate)", orientation="horizontal", fraction=0.05)
 
-        Ns = [n.N for n in node_nuclei]
-        Zs = [n.Z for n in node_nuclei]
-
         if not rotated:
             plt.xlabel(r"$N$", fontsize="large")
             plt.ylabel(r"$Z$", fontsize="large")

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -1732,13 +1732,6 @@ class RateCollection:
         Zs = [n.Z for n in node_nuclei]
 
         if not rotated:
-            ax.set_xlim(min(Ns)-1, max(Ns)+1)
-        else:
-            ax.set_xlim(min(Zs)-1, max(Zs)+1)
-
-        #plt.ylim(min(Zs)-1, max(Zs)+1)
-
-        if not rotated:
             plt.xlabel(r"$N$", fontsize="large")
             plt.ylabel(r"$Z$", fontsize="large")
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # runtime dependencies
 ipywidgets>=7.1.2
-matplotlib<3.10.0
+matplotlib
 networkx>=2.1
 numpy>=1.13.3,<3.0
 scipy>=1.0.0


### PR DESCRIPTION
we are requiring that the axes use "datalim", so this is redundant. This removes a warning introduced in matplotlib 3.10.0