### PR TITLE
pin matplotlib < 3.10.0 temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # runtime dependencies
 ipywidgets>=7.1.2
-matplotlib>=2.1.0
+matplotlib<3.10.0
 networkx>=2.1
 numpy>=1.13.3,<3.0
 scipy>=1.0.0


### PR DESCRIPTION
this added a new warning that causes CI troubles