### PR TITLE
Fix citations in notebooks after switching to myst-nb

### DIFF
--- a/docs/source/NSE-example.ipynb
+++ b/docs/source/NSE-example.ipynb
@@ -14,8 +14,7 @@
     "pynucastro is able to calculate the abundances at nuclear statistical equilibrium of a given reaction network.\n",
     "\n",
     "The constrained equations are setup following\n",
-    "<cite data-cite-t=\"calder:2007\">Calder et al. (2007)</cite> and\n",
-    "<cite data-cite-t=\"seitenzahl:2009\">Seitenzahl et al. (2009)</cite>\n",
+    "{cite:t}`calder:2007` and {cite:t}`seitenzahl:2009`\n",
     "and solved using `scipy.optimize.fsolve()`.\n",
     "\n",
     "Here we show how to find the NSE state of a set of nuclei."

--- a/docs/source/electron-capture-example.ipynb
+++ b/docs/source/electron-capture-example.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "Let's create a network with these rates.\n",
     "\n",
-    "pynucastro will use the tabulated rates from <cite data-cite-t=\"langanke:2001\">Langanke & Martinez-Pinedo (2001)</cite>."
+    "pynucastro will use the tabulated rates from {cite:t}`langanke:2001`."
    ]
   },
   {
@@ -282,7 +282,7 @@
    "id": "0652257d-79a5-43c8-8886-dca4f8343c61",
    "metadata": {},
    "source": [
-    "If we look at the original tables from <cite data-cite-t=\"langanke:2001\">Langanke & Martinez-Pinedo (2001)</cite>, they tabulate (for the conditions we selected above):\n",
+    "If we look at the original tables from {cite:t}`langanke:2001`, they tabulate (for the conditions we selected above):\n",
     "\n",
     "```\n",
     " neg. daughter Ni56 z=28 n=28 a=56 Q= -1.6240                                           \n",

--- a/docs/source/electron-captures.ipynb
+++ b/docs/source/electron-captures.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here's an example of using tabulated weak rates from <cite data-cite-t=\"suzuki:2016\">Suzuki et al. (2016)</cite> together with rates from the ReacLib database.\n",
+    "Here's an example of using tabulated weak rates from {cite:t}`suzuki:2016` together with rates from the ReacLib database.\n",
     "\n",
     "We'll build a network suitable for e-capture supernovae."
    ]
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's specify the weak rates we want from <cite data-cite-t=\"suzuki:2016\">Suzuki et al.</cite> -- these tables are included with pynucastro:"
+    "Now let's specify the weak rates we want from {cite:t}`suzuki:2016` -- these tables are included with pynucastro:"
    ]
   },
   {

--- a/docs/source/neutrino-cooling.ipynb
+++ b/docs/source/neutrino-cooling.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "At high temperatures, pair, plasma, Bremmstrahlung, and photo neutrinos become important. These are often treated as a source term to an energy equation when integrating the temperature evolution due to reactions.\n",
     "\n",
-    "pynucastro implements the functions of <cite data-cite-t=\"itoh:1996\">Itoh et al. 1996</cite> to incorporate these effects.  In many codes, a routine called ``sneut5`` was used for this implementation.  pynucastro contains a port of that routine."
+    "pynucastro implements the functions of {cite:t}`itoh:1996` to incorporate these effects.  In many codes, a routine called ``sneut5`` was used for this implementation.  pynucastro contains a port of that routine."
    ]
   },
   {

--- a/docs/source/screening-examples.ipynb
+++ b/docs/source/screening-examples.ipynb
@@ -41,10 +41,10 @@
    "source": [
     "pynucastro currently has 4 screening implementations:\n",
     "\n",
-    "* `screen5` based on <cite data-cite-t=\"Wallace:1982\">Wallace et al. (1982)</cite>\n",
-    "* `potekhin_1998` based on <cite data-cite-t=\"chabrier_potekhin:1998\">Chabrier & Potekhin (1998)</cite>\n",
-    "* `chugunov_2007` based on <cite data-cite-t=\"chugunov:2007\">Chugunov et al. (2007)</cite>\n",
-    "* `chugunov_2009` based on <cite data-cite-t=\"chugunov:2009\">Chugunov & DeWitt (2009)</cite>\n",
+    "* `screen5` based on {cite:t}`Wallace:1982`\n",
+    "* `potekhin_1998` based on {cite:t}`chabrier_potekhin:1998`\n",
+    "* `chugunov_2007` based on {cite:t}`chugunov:2007`\n",
+    "* `chugunov_2009` based on {cite:t}`chugunov:2009`\n",
     "\n",
     "Each of these use various approximations to account for the influence of the plasma on screening the electric charge of the nuclei that are fusing."
    ]


### PR DESCRIPTION
This is much cleaner now, and uses the same roles as the ReST files. It's documented here, for reference: https://mystmd.org/guide/citations#citation-roles