### PR TITLE
allow executing of notebooks to be skipped

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,22 @@ to squash commits upon merge to have a clean history.  *Please ensure
 that your PR title and first post are descriptive, since these will be
 used for a squashed commit message.*
 
+## Documentation
+
+The documentation is in `docs/source` and uses MyST-flavored markdown,
+managed by Sphinx.  To build the docs, in the `docs/` directory, do:
+
+```
+make html
+```
+
+by default, this will execute all of the Jupyter notebooks.  To skip this,
+build as:
+
+```
+SKIP_EXECUTE=TRUE make html
+```
+
 ## Testing
 
 We use pytest to do unit and regression tests. All commands should be

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,7 @@ templates_path = ['_templates']
 # always execute notebooks
 env_skip_execute = os.getenv("SKIP_EXECUTE")
 
-if env_skip_execute:
+if not env_skip_execute:
     nb_execution_mode = "force"
 else:
     nb_execution_mode = "off"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,7 @@ templates_path = ['_templates']
 # always execute notebooks
 env_skip_execute = os.getenv("SKIP_EXECUTE")
 
-if env_skip_execute is None:
+if env_skip_execute:
     nb_execution_mode = "force"
 else:
     nb_execution_mode = "off"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use pathlib.Path.resolve to make it absolute, like shown here.
 #
+import os
 import sys
 from pathlib import Path
 from importlib.metadata import version as importlib_version
@@ -64,7 +65,13 @@ linkcheck_allow_unauthorized = True
 templates_path = ['_templates']
 
 # always execute notebooks
-nbsphinx_execute = 'always'
+env_skip_execute = os.getenv("SKIP_EXECUTE")
+
+if env_skip_execute is None:
+    nb_execution_mode = "force"
+else:
+    nb_execution_mode = "off"
+
 nbsphinx_allow_errors = True
 nbsphinx_timeout = 1000
 


### PR DESCRIPTION
now if we build with "SKIP_EXECUTE make html", sphinx will not
force-execute the Jupyter notebooks
