### PR TITLE
Update required networkx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # runtime dependencies
 ipywidgets>=7.1.2
 matplotlib
-networkx>=2.1
+networkx>=3.3
 numpy>=1.13.3,<3.0
 scipy>=1.0.0
 sympy>=1.1.1
@@ -27,4 +27,4 @@ sphinx_rtd_theme>=1.1.0
 sphinxcontrib-bibtex
 sphinx-book-theme
 myst-nb
-jupyterlab_myst
+jupyterlab-myst


### PR DESCRIPTION
I got an error when running locally with networkx 3.2.1 about the `connectionstyle` argument to `nx.draw_networkx_edge_labels()`, which is only available since networkx 3.3.

Also fix jupyterlab-myst so it works with conda-forge.