### PR TITLE
have isort skip auto-generated _version.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,8 @@ skip = ".git,*docs/build,*.bib"
 
 [tool.isort]
 known_first_party = ["pynucastro"]
-skip = ["pynucastro/networks/tests/_python_reference/network.py"]
+skip = ["pynucastro/networks/tests/_python_reference/network.py",
+        "pynucastro/_version.py"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
this seems needed with the latest version of isort