### PR TITLE
don't store rate file lines as Library data

### DIFF
--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -122,7 +122,6 @@ class Library:
     """
 
     def __init__(self, libfile=None, rates=None):
-        self._library_file = libfile
         self._rates = {}
 
         if rates:
@@ -135,11 +134,9 @@ class Library:
             else:
                 raise TypeError("rates in Library constructor must be a Rate object, list of Rate objects, or dictionary of Rate objects keyed by Rate.id")
 
-        self._library_source_lines = collections.deque()
-
-        if self._library_file:
-            self._library_file = _find_rate_file(self._library_file)
-            self._read_library_file()
+        if libfile:
+            library_file = _find_rate_file(libfile)
+            self._read_library_file(library_file)
 
     def get_rates(self):
         """ Return a list of the rates in this library."""
@@ -253,46 +250,49 @@ class Library:
                 nuc = rnuc
         return nuc
 
-    def _read_library_file(self):
+    def _read_library_file(self, library_file):
         # loop through library file, read lines
 
-        with self._library_file.open("r") as flib:
+        library_source_lines = collections.deque()
+
+
+        with library_file.open("r") as flib:
             for line in flib:
                 ls = line.rstrip('\n')
                 if ls.strip():
-                    self._library_source_lines.append(ls)
+                    library_source_lines.append(ls)
 
         # identify distinct rates from library lines
         current_chapter = None
         while True:
-            if len(self._library_source_lines) == 0:
+            if len(library_source_lines) == 0:
                 break
 
             # Check to see if there is a chapter ID, if not then use current_chapter
             # (for Reaclib v1 formatted library files)
-            line = self._library_source_lines[0].strip()
+            line = library_source_lines[0].strip()
             chapter = None
             if line in ('t', 'T'):
                 chapter = 't'
-                self._library_source_lines.popleft()
+                library_source_lines.popleft()
             else:
                 try:
                     chapter = int(line)
                 except (TypeError, ValueError):
                     # we can't interpret line as a chapter so use current_chapter
-                    assert current_chapter, f'malformed library file {self._library_file}, cannot identify chapter.'
+                    assert current_chapter, f'malformed library file {library_file}, cannot identify chapter.'
                     chapter = current_chapter
                 else:
-                    self._library_source_lines.popleft()
+                    library_source_lines.popleft()
             current_chapter = chapter
 
             rlines = None
             rate_type = None
             if chapter == 't':
-                rlines = [self._library_source_lines.popleft() for i in range(5)]
+                rlines = [library_source_lines.popleft() for i in range(5)]
                 rate_type = "tabular"
             elif isinstance(chapter, int):
-                rlines = [self._library_source_lines.popleft() for i in range(3)]
+                rlines = [library_source_lines.popleft() for i in range(3)]
                 rate_type = "reaclib"
             if rlines:
                 sio = io.StringIO('\n'.join([f'{chapter}'] +

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -351,7 +351,7 @@ class Library:
         for rid, r in other._rates.items():
             if rid in new_rates:
                 if r != new_rates[rid]:
-                    raise ValueError(f'rate {r} defined differently in libraries {self._library_file} and {other._library_file}')
+                    raise ValueError(f'rate {r} defined differently in libraries')
             else:
                 new_rates[rid] = r
         new_library = Library(rates=new_rates)


### PR DESCRIPTION
now _read_library_file takes the name of the library file directly,
instead of storing it as class data.