### PR TITLE
fix math rendering issue in Jacobian scaling

### DIFF
--- a/docs/source/plot-types.ipynb
+++ b/docs/source/plot-types.ipynb
@@ -456,7 +456,7 @@
     "We can visualize the Jacobian of our network easily.  By default, we will show all elements\n",
     "where \n",
     "\n",
-    "$$\\frac{\\mathrm{max}_{i,j} (|J_{ij}|)}{|J_{ij}|} > 10^{10}$$\n",
+    "$$\\frac{\\max_{i,j} (|J_{ij}|)}{|J_{ij}|} > 10^{10}$$\n",
     "\n",
     "but this ratio can be set via the `rate_scaling` keyword argument."
    ]


### PR DESCRIPTION
using \max instead of \mathrm{max} seems to fix things