### PR TITLE
Removing @property decorator status of ye, abar, and zbar

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -279,7 +279,7 @@ class Composition(collections.UserDict):
         for k in self:
             self[k] /= X_sum
 
-    @property
+
     def ye(self):
         """Return the electron fraction of the composition
 
@@ -290,7 +290,7 @@ class Composition(collections.UserDict):
         electron_frac = math.fsum(self[n] * n.Z / n.A for n in self) / self.get_sum_X()
         return electron_frac
 
-    @property
+
     def abar(self):
         """Return the mean molecular weight
 
@@ -301,7 +301,7 @@ class Composition(collections.UserDict):
         abar = math.fsum(self[n] / n.A for n in self)
         return 1. / abar
 
-    @property
+
     def zbar(self):
         """Return the mean charge, Zbar
 


### PR DESCRIPTION
From the `Composition` class we hold three important class methods to compute `ye`, `abar` and `zbar`. Because these methods are decorated as @property, they should hold the same `self` data structure. However, these functions return a float number and not a dictionary. This PR solves this bug.