### PR TITLE
Allow to use ModifiedRate as input for DerivedRate

### DIFF
--- a/pynucastro/rates/derived_rate.py
+++ b/pynucastro/rates/derived_rate.py
@@ -104,6 +104,11 @@ class DerivedRate(ReacLibRate):
         # explicitly mark it as reverse
         self.reverse = True
 
+        # Mark as modified if the forward rate is modified
+        self.modified = self.rate.modified
+
+        super()._set_print_representation()
+
     def _warn_about_missing_pf_tables(self):
         skip_nuclei = {Nucleus("h1"), Nucleus("n"), Nucleus("he4")}
         for nuc in set(self.rate.reactants + self.rate.products) - skip_nuclei:

--- a/pynucastro/rates/derived_rate.py
+++ b/pynucastro/rates/derived_rate.py
@@ -9,6 +9,7 @@ from pynucastro.nucdata import Nucleus
 from pynucastro.rates.rate import Rate
 from pynucastro.rates.reaclib_rate import ReacLibRate, SingleSet
 from pynucastro.rates.tabular_rate import TabularRate
+from pynucastro.rates.modified_rate import ModifiedRate
 
 
 class DerivedRate(ReacLibRate):
@@ -46,7 +47,14 @@ class DerivedRate(ReacLibRate):
             raise ValueError('One of the products spin ground state, is not defined')
 
         derived_sets = []
-        for ssets in self.rate.sets:
+
+        # The original rate of the modified rate is assumed to be ReacLibRate
+        if isinstance(rate, ModifiedRate):
+            r = self.rate.original_rate
+        else:
+            r = self.rate
+
+        for ssets in r.sets:
             a = ssets.a
             prefactor = 0.0
             Q = 0.0
@@ -84,11 +92,11 @@ class DerivedRate(ReacLibRate):
             a_rev[5] = a[5]
             a_rev[6] = a[6] + 1.5*(len(self.rate.reactants) -
                                    len(self.rate.products))
-            sset_d = SingleSet(a=a_rev, labelprops=rate.labelprops)
+            sset_d = SingleSet(a=a_rev, labelprops=r.labelprops)
             derived_sets.append(sset_d)
 
-        super().__init__(rfile=self.rate.rfile, chapter=self.rate.chapter,
-                         original_source=self.rate.original_source,
+        super().__init__(rfile=r.rfile, chapter=r.chapter,
+                         original_source=r.original_source,
                          reactants=self.rate.products,
                          products=self.rate.reactants,
                          sets=derived_sets, labelprops="derived", Q=-Q)

--- a/pynucastro/rates/modified_rate.py
+++ b/pynucastro/rates/modified_rate.py
@@ -55,6 +55,11 @@ class ModifiedRate(Rate):
 
         self.chapter = "m"
 
+        try:
+            self.weak = original_rate.weak
+        except ValueError:
+            self.weak = False
+
         # update the Q value
         if new_products or new_reactants:
             self._set_q()

--- a/pynucastro/rates/modified_rate.py
+++ b/pynucastro/rates/modified_rate.py
@@ -54,6 +54,7 @@ class ModifiedRate(Rate):
                          stoichiometry=stoichiometry)
 
         self.chapter = "m"
+        self.modified = True
 
         try:
             self.weak = original_rate.weak
@@ -63,6 +64,8 @@ class ModifiedRate(Rate):
         # update the Q value
         if new_products or new_reactants:
             self._set_q()
+
+        super()._set_print_representation()
 
     def _set_screening(self):
         """Determine if this rate is eligible for screening and the


### PR DESCRIPTION
Uses the original rate of ModifiedRate as input for DerivedRate.  Doing so will allow us to use ModifiedRate in the network to be compatible with NSE.

Also updates printing representation.  In the case where the derived rate is from modified rate, cname will print out as `xxxxx_modified_derived`