### PR TITLE
remove setup.py and setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-# Needed to display a Home-page URL when running `pip show`.
-# See https://github.com/pypa/packaging-problems/issues/606
-[metadata]
-url = https://github.com/pynucastro/pynucastro

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
these are no longer needed
the previous issue with the homepage in `pip show` needed the `setup.cfg` is no longer an issue.