### PR TITLE
refactor Fermi-Dirac kernels for roundoff

### DIFF
--- a/pynucastro/eos/fermi_integrals.py
+++ b/pynucastro/eos/fermi_integrals.py
@@ -312,22 +312,17 @@ class FermiIntegral:
 
         N = len(x_leg)//2
 
-        integral = 0
-
         # We set the correspondence (a+b)/2 -> 0 and map the (-1,0) and (0,1)
         # intervals separately.
 
         fac1 = (a + b)/2
         fac2 = (b - a)/2
 
-        for root, weight in zip(x_leg[N:], w_leg[N:]):
-            x_1 = fac1 + fac2 * root
-            x_2 = fac1 - fac2 * root
-            qder_1 = kernel(x_1, k, eta, beta,
-                            eta_der=eta_der, beta_der=beta_der)
-            qder_2 = kernel(x_2, k, eta, beta,
-                            eta_der=eta_der, beta_der=beta_der)
-            integral += (qder_1 + qder_2) * weight
+        integral = sum((kernel(fac1 + fac2 * root, k, eta, beta,
+                               eta_der=eta_der, beta_der=beta_der) +
+                        kernel(fac1 - fac2 * root, k, eta, beta,
+                               eta_der=eta_der, beta_der=beta_der)) * weight
+                       for root, weight in zip(x_leg[N:], w_leg[N:]))
 
         integral *= (b - a) / 2
         return integral

--- a/pynucastro/eos/fermi_integrals.py
+++ b/pynucastro/eos/fermi_integrals.py
@@ -134,51 +134,57 @@ def _kernel_p(x, k, eta, beta,
     xsq = x * x
     sqrt_term = np.sqrt(1.0 + 0.5 * x * x * beta)
     num = 2.0 * x**(2*k + 1.0) * sqrt_term
-    denomi = 1.0 / (np.exp(xsq - eta) + 1.0)
-    test = xsq - eta < -700.0
+    # this is what we are usually exponentiating
+    delta = xsq - eta
+    cosh_delta = np.cosh(delta)  # this is 0.5 * (exp(xsq - eta) + exp(eta - xsq))
+    testm = delta < -700.0
+    if testm:
+        denomi = 1.0
+        exp_delta = 0.0
+    else:
+        exp_delta = np.exp(delta)
+        inv_exp_delta = 1.0 / exp_delta
+        # 1 / (exp(x**2 - eta) + 1) rewritten
+        denomi = inv_exp_delta / (1.0 + inv_exp_delta)
 
     # now construct the integrand for what we are actual computing
     if eta_der == 0 and beta_der == 0:
-        if test:
-            result = num
-        else:
-            result = num * denomi
+        result = num
+        if not testm:
+            result *= denomi
 
     elif eta_der == 1 and beta_der == 0:
         # this is IB = 1 from Gong et al.
         # this corresponds to eq A.1 in terms of x**2
-        if not test:
-            result = num / (np.exp(xsq - eta) + 2.0 + np.exp(eta - xsq))
+        if not testm:
+            result = num / (2.0 * (1.0 + cosh_delta))
 
     elif eta_der == 0 and beta_der == 1:
         # this is IB = 2 from Gong et al.
         # this corresponds to eq A.2 in terms of x**2
-        if test:
-            result = 0.5 * x**(2.0*k + 3.0) / sqrt_term
-        else:
-            result = 0.5 * x**(2.0*k + 3.0) * denomi / sqrt_term
+        result = 0.5 * x**(2.0*k + 3.0) / sqrt_term
+        if not testm:
+            result *= denomi
 
     elif eta_der == 2 and beta_der == 0:
         # this is IB = 3 from Gong et al.
         # this corresponds to eq A.3 in terms of x**2
-        if not test:
-            result = num / (np.exp(xsq - eta) + 2.0 + np.exp(eta - xsq)) * \
+        if not testm:
+            result = num / (2.0 * (1.0 + cosh_delta)) * \
                 ((np.exp(xsq - eta) - 1.0) / (np.exp(xsq - eta) + 1.0))
 
     elif eta_der == 1 and beta_der == 1:
         # this is IB = 4 from Gong et al.
         # this corresponds to eq A.4 in terms of x**2
-        if not test:
-            result = 0.5 * x**(2.0*k + 3.0) / \
-                (np.exp(xsq - eta) + 2.0 + np.exp(eta - xsq)) / sqrt_term
+        if not testm:
+            result = 0.5 * x**(2.0*k + 3.0) / (2.0 * (1.0 + cosh_delta)) / sqrt_term
 
     elif eta_der == 0 and beta_der == 2:
         # this is IB = 5 from Gong et al.
         # this corresponds to eq A.5 in terms of x**2
-        if test:
-            result = -0.125 * x**(2.0*k + 5.0) / sqrt_term**3
-        else:
-            result = -0.125 * x**(2.0*k + 5.0) * denomi / sqrt_term**3
+        result = -0.125 * x**(2.0*k + 5.0) / sqrt_term**3
+        if not testm:
+            result *= denomi
 
     return result
 
@@ -193,47 +199,57 @@ def _kernel_E(x, k, eta, beta,
 
     sqrt_term = np.sqrt(1.0 + 0.5 * x * beta)
     num = x**k * sqrt_term
-    test = x - eta < 700
-    denomi = 1.0
-    if test:
-        denomi = 1.0 / (np.exp(x - eta) + 1.0)
+    # this is what we are usually exponentiating
+    delta = x - eta
+    cosh_delta = np.cosh(delta)
+    testm = x - eta < -700
+    if testm:
+        denomi = 1.0
+        exp_delta = 0.0
+    else:
+        exp_delta = np.exp(delta)
+        inv_exp_delta = 1.0 / exp_delta
+        # 1 / (exp(x - eta) + 1) rewritten
+        denomi = inv_exp_delta / (1.0 + inv_exp_delta)
 
     # now construct the integrand for what we are actual computing
     if eta_der == 0 and beta_der == 0:
-        if test:
-            result = num * denomi
+        result = num
+        if not testm:
+            result *= denomi
 
     elif eta_der == 1 and beta_der == 0:
         # this is IB = 1 from Gong et al.
         # this corresponds to eq A.1
-        if test:
-            result = num / (np.exp(x - eta) + 2.0 + np.exp(eta - x))
+        if not testm:
+            result = num / (2.0 * (1.0 + cosh_delta))
 
     elif eta_der == 0 and beta_der == 1:
         # this is IB = 2 from Gong et al.
         # this corresponds to eq A.2
-        if test:
-            result = 0.25 * x**(k + 1.0) * denomi / sqrt_term
+        result = 0.25 * x**(k + 1.0)  / sqrt_term
+        if not testm:
+            result *= denomi
 
     elif eta_der == 2 and beta_der == 0:
         # this is IB = 3 from Gong et al.
         # this corresponds to eq A.3
-        if test:
-            result = num / (np.exp(x - eta) + 2.0 + np.exp(eta - x)) * \
+        if not testm:
+            result = num / (2.0 * (1.0 + cosh_delta)) * \
                 ((1.0 - np.exp(eta - x)) / (1.0 + np.exp(eta - x)))
 
     elif eta_der == 1 and beta_der == 1:
         # this is IB = 4 from Gong et al.
         # this corresponds to eq A.4
-        if test:
-            result = 0.25 * x**(k + 1.0) / \
-                (np.exp(x - eta) + 2.0 + np.exp(eta - x)) / sqrt_term
+        if not testm:
+            result = 0.25 * x**(k + 1.0) / (2.0 * (1.0 + cosh_delta)) / sqrt_term
 
     elif eta_der == 0 and beta_der == 2:
         # this is IB = 5 from Gong et al.
         # this corresponds to eq A.5
-        if test:
-            result = -0.0625 * x**(k + 2.0) * denomi / sqrt_term**3
+        result = -0.0625 * x**(k + 2.0) / sqrt_term**3
+        if not testm:
+            result *= denomi
 
     return result
 

--- a/pynucastro/eos/fermi_integrals.py
+++ b/pynucastro/eos/fermi_integrals.py
@@ -137,6 +137,7 @@ def _kernel_p(x, k, eta, beta,
     # this is what we are usually exponentiating
     delta = xsq - eta
     cosh_delta = np.cosh(delta)  # this is 0.5 * (exp(xsq - eta) + exp(eta - xsq))
+    tanh_half_delta = np.tanh(0.5 * delta)  # this is (exp(xsq - eta) - 1.0) / (exp(xsq - eta) + 1.0)
     testm = delta < -700.0
     if testm:
         denomi = 1.0
@@ -170,8 +171,7 @@ def _kernel_p(x, k, eta, beta,
         # this is IB = 3 from Gong et al.
         # this corresponds to eq A.3 in terms of x**2
         if not testm:
-            result = num / (2.0 * (1.0 + cosh_delta)) * \
-                ((np.exp(xsq - eta) - 1.0) / (np.exp(xsq - eta) + 1.0))
+            result = num / (2.0 * (1.0 + cosh_delta)) * tanh_half_delta
 
     elif eta_der == 1 and beta_der == 1:
         # this is IB = 4 from Gong et al.
@@ -202,6 +202,7 @@ def _kernel_E(x, k, eta, beta,
     # this is what we are usually exponentiating
     delta = x - eta
     cosh_delta = np.cosh(delta)
+    tanh_half_delta = np.tanh(0.5 * delta)  # this is (exp(x - eta) - 1.0) / (exp(x - eta) + 1.0)
     testm = x - eta < -700
     if testm:
         denomi = 1.0
@@ -227,7 +228,7 @@ def _kernel_E(x, k, eta, beta,
     elif eta_der == 0 and beta_der == 1:
         # this is IB = 2 from Gong et al.
         # this corresponds to eq A.2
-        result = 0.25 * x**(k + 1.0)  / sqrt_term
+        result = 0.25 * x**(k + 1.0) / sqrt_term
         if not testm:
             result *= denomi
 
@@ -235,8 +236,7 @@ def _kernel_E(x, k, eta, beta,
         # this is IB = 3 from Gong et al.
         # this corresponds to eq A.3
         if not testm:
-            result = num / (2.0 * (1.0 + cosh_delta)) * \
-                ((1.0 - np.exp(eta - x)) / (1.0 + np.exp(eta - x)))
+            result = num / (2.0 * (1.0 + cosh_delta)) * tanh_half_delta
 
     elif eta_der == 1 and beta_der == 1:
         # this is IB = 4 from Gong et al.

--- a/pynucastro/eos/tests/test_fd.py
+++ b/pynucastro/eos/tests/test_fd.py
@@ -59,7 +59,7 @@ class TestFermiDirac:
         assert f.F == approx(883930.45936891437, abs=1.e-100, rel=1.e-15)
         assert f.dF_deta == approx(3535.6046159037460, abs=1.e-100, rel=1.e-15)
         assert f.dF_dbeta == approx(4419.2988177917523, abs=1.e-100, rel=1.e-15)
-        assert f.d2F_deta2 == approx(7.0710678132825819, abs=1.e-100, rel=1.e-15)
+        assert f.d2F_deta2 == approx(7.0710678132825819, abs=1.e-100, rel=1.e-14)
         assert f.d2F_detadbeta == approx(17.677315986879442, abs=1.e-100, rel=1.e-15)
         assert f.d2F_dbeta2 == approx(-22.094727366363866, abs=1.e-100, rel=1.e-15)
 

--- a/pynucastro/eos/tests/test_fd.py
+++ b/pynucastro/eos/tests/test_fd.py
@@ -59,7 +59,7 @@ class TestFermiDirac:
         assert f.F == approx(883930.45936891437, abs=1.e-100, rel=1.e-15)
         assert f.dF_deta == approx(3535.6046159037460, abs=1.e-100, rel=1.e-15)
         assert f.dF_dbeta == approx(4419.2988177917523, abs=1.e-100, rel=1.e-15)
-        assert f.d2F_deta2 == approx(7.0710678132825819, abs=1.e-100, rel=1.e-14)
+        assert f.d2F_deta2 == approx(7.0710678132825819, abs=1.e-100, rel=1.e-15)
         assert f.d2F_detadbeta == approx(17.677315986879442, abs=1.e-100, rel=1.e-15)
         assert f.d2F_dbeta2 == approx(-22.094727366363866, abs=1.e-100, rel=1.e-15)
 
@@ -101,9 +101,9 @@ class TestFermiDirac:
         f.evaluate()
 
         assert f.F == approx(707.87776608227455, abs=1.e-100, rel=1.e-15)
-        assert f.dF_deta == approx(7.0717751162111329, abs=1.e-100, rel=1.e-15)
+        assert f.dF_deta == approx(7.0717751162111329, abs=1.e-100, rel=1.e-11)
         assert f.dF_dbeta == approx(3.5323860528718423, abs=1.e-100, rel=1.e-15)
-        assert f.d2F_deta2 == approx(-7.0773544184610238E-006, abs=1.e-100, rel=1.e-15)
+        assert f.d2F_deta2 == approx(-7.0773544184610238E-006, abs=1.e-100, rel=1.e-11)
         assert f.d2F_detadbeta == approx(3.5351802891431347E-002, abs=1.e-100, rel=1.e-15)
         assert f.d2F_dbeta2 == approx(-1.7633986737239839E-002, abs=1.e-100, rel=1.e-15)
 


### PR DESCRIPTION
These are analytically equivalent, but have better roundoff and overflow protection.  A few tolerances against the Gong code needed to be relaxed.