### PR TITLE
update pyproject.toml license info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018, pynucastro developers
+Copyright (c) 2025, pynucastro developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "pynucastro"
 description = "A python library for nuclear astrophysics"
 readme = "README.md"
-license.text = "BSD"
+license = "BSD-3-Clause"
 authors = [
   {name="pynucastro development group"},
   {email="michael.zingale@stonybrook.edu"},


### PR DESCRIPTION
the current method is deprecated
this also bumps up setuptools to a version that supports the new method, and updates the LICENSE copyright year.