### PR TITLE
Load in spins determined by both strong and weak experimental arguments

### DIFF
--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -17,7 +17,7 @@ _pynucastro_tabular_dir = _pynucastro_rates_dir/'tabular'
 # read the various tables with nuclear properties at the module-level
 _mass_table = MassTable()
 _halflife_table = HalfLifeTable()
-_spin_table = SpinTable(reliable=True)
+_spin_table = SpinTable(reliable=False)
 
 # read the partition function table once and store it at the module-level
 _pcollection = PartitionFunctionCollection(use_high_temperatures=True, use_set='frdm')


### PR DESCRIPTION
This changes the default behavior of the spin table. Previously, we used spins that were denoted by * or no special chars in NUBASE 2020 (doi:10.1088/1674-1137/abddae), and left off spins that were denoted by # or in parentheses. This means we included experimental information based on strong arguments and excluded information based on both theory and weak experimental arguments. In discussion, it seems that we prefer to have all spin data available, so this PR makes that the default behavior.

I don't like locking out the ability to choose more reliable spins, however, so I plan to make another PR that will make that an option. But I wanted to separate out the change to default behavior from the change to the interface, so that will be separate.