### PR TITLE
Allow a RateCollection or a Nucleus to restrict spins to only experimentally reliable ones

### DIFF
--- a/docs/source/nucleus.ipynb
+++ b/docs/source/nucleus.ipynb
@@ -185,10 +185,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "dd9a3952",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ni56.spin_states"
    ]
@@ -203,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "78fd323e-e572-4c4c-9327-cb707b1489b4",
    "metadata": {},
    "outputs": [
@@ -227,7 +238,8 @@
       "  spin states: 1\n",
       "\n",
       "  dummy: False\n",
-      "  nse: False\n"
+      "  nse: False\n",
+      "  requiring reliable spin: False\n"
      ]
     }
    ],
@@ -264,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b4b5eabd-7a35-432d-a0a0-c0b92db4f3cc",
    "metadata": {},
    "outputs": [
@@ -274,7 +286,7 @@
        "N13"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -288,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "edafb690-83ad-4967-96cb-672b1c32608f",
    "metadata": {},
    "outputs": [
@@ -298,7 +310,7 @@
        "12114.76881146"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "bfa282e0-4fb5-4d70-b24f-544d83d266f9",
    "metadata": {},
    "outputs": [
@@ -319,7 +331,7 @@
        "B11"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -346,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "07fc3312-491c-4949-89b0-a17838f7c752",
    "metadata": {},
    "outputs": [],
@@ -361,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ad96edc6-1705-4573-a086-0f8097af8e52",
    "metadata": {},
    "outputs": [
@@ -410,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "36458c33-9472-4525-8967-dba557674a04",
    "metadata": {},
    "outputs": [],
@@ -428,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "72e24505-ab91-4822-9544-cfeee7926579",
    "metadata": {},
    "outputs": [
@@ -438,7 +450,7 @@
        "1.1368683772161603e-13"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "fa1b6fba",
    "metadata": {},
    "outputs": [],
@@ -467,21 +479,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "e4d3e3c5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
    "source": [
     "fe61.reliable_spin = True\n",
-    "fe61.spin_states"
+    "print(fe61.spin_states)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "cde8f0fd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fe61.reliable_spin = False\n",
     "fe61.spin_states"
@@ -490,7 +521,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -504,7 +535,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/docs/source/nucleus.ipynb
+++ b/docs/source/nucleus.ipynb
@@ -184,6 +184,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd9a3952",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ni56.spin_states"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "66f657fb-a7c3-4f1b-915f-48482172af6e",
    "metadata": {},
@@ -435,6 +445,46 @@
    ],
    "source": [
     "c12.mass / 12 - constants.m_u_MeV_C18"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d54ad764",
+   "metadata": {},
+   "source": [
+    "Let's look at a less common nucleus. From Nubase 2020 data, the spin for ${}^{61}\\mathrm{Fe}$ is determined experimentally but the argument to determine it was judged to be weak. We are able to choose whether to use these unreliable spin data or omit them. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa1b6fba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fe61 = Nucleus(\"fe61\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4d3e3c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fe61.reliable_spin = True\n",
+    "fe61.spin_states"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cde8f0fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fe61.reliable_spin = False\n",
+    "fe61.spin_states"
    ]
   }
  ],

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -574,6 +574,9 @@ class RateCollection:
     do_screening : bool
         should we consider screening at all -- this mainly affects
         whether we build the screening map
+    reliable_spins : bool
+        should we omit spin data that are arrived at through either 
+        theoretical means or experimentally weak arguments 
     """
 
     pynucastro_dir = Path(__file__).parents[1]

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -580,7 +580,8 @@ class RateCollection:
 
     def __init__(self, rate_files=None, libraries=None, rates=None,
                  inert_nuclei=None,
-                 symmetric_screening=False, do_screening=True):
+                 symmetric_screening=False, do_screening=True,
+                 reliable_spins=False):
 
         self.rates = []
         combined_library = Library()
@@ -589,6 +590,7 @@ class RateCollection:
 
         self.symmetric_screening = symmetric_screening
         self.do_screening = do_screening
+        self.reliable_spins = reliable_spins
 
         if rate_files:
             if isinstance(rate_files, str):
@@ -638,6 +640,10 @@ class RateCollection:
             for nuc in self.inert_nuclei:
                 if nuc not in self.unique_nuclei:
                     self.unique_nuclei.append(nuc)
+
+        if self.reliable_spins:
+            for n in self.unique_nuclei + self.approx_nuclei:
+                n.reliable_spin = True
 
         # now make a list of each rate that touches each nucleus
         # we'll store this in a dictionary keyed on the nucleus

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -575,8 +575,8 @@ class RateCollection:
         should we consider screening at all -- this mainly affects
         whether we build the screening map
     reliable_spins : bool
-        should we omit spin data that are arrived at through either 
-        theoretical means or experimentally weak arguments 
+        should we omit spin data that are arrived at through either
+        theoretical means or experimentally weak arguments
     """
 
     pynucastro_dir = Path(__file__).parents[1]

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -308,6 +308,7 @@ class Nucleus:
         print("")
         print(f"  dummy: {self.dummy}")
         print(f"  nse: {self.nse}")
+        print(f"  requiring reliable spin: {self.reliable_spin}")
 
     def __repr__(self):
         if self.raw not in ("p", "p_nse", "d", "t", "n"):

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -77,6 +77,9 @@ class Nucleus:
     nse : bool
         an NSE proton has the same properties
         as a proton but compares as being distinct
+    reliable_spin : bool
+        whether to require experimentally strong arguments for
+        spin values (True) or to accept any argument (False)
     """
 
     _cache = {}
@@ -87,6 +90,7 @@ class Nucleus:
 
         self.dummy = dummy
         self.nse = False
+        self.reliable_spin = False
 
         # element symbol and atomic weight
         if name == "p":
@@ -173,7 +177,7 @@ class Nucleus:
 
         # set the number of spin states
         try:
-            self.spin_states = _spin_table.get_spin_states(a=self.A, z=self.Z)
+            self.spin_states = _spin_table.get_spin_states(a=self.A, z=self.Z, reliable=self.reliable_spin)
         except NotImplementedError:
             self.spin_states = None
 

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -17,7 +17,7 @@ _pynucastro_tabular_dir = _pynucastro_rates_dir/'tabular'
 # read the various tables with nuclear properties at the module-level
 _mass_table = MassTable()
 _halflife_table = HalfLifeTable()
-_spin_table = SpinTable(reliable=False)
+_spin_table = SpinTable()
 
 # read the partition function table once and store it at the module-level
 _pcollection = PartitionFunctionCollection(use_high_temperatures=True, use_set='frdm')

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -90,7 +90,7 @@ class Nucleus:
 
         self.dummy = dummy
         self.nse = False
-        self.reliable_spin = False
+        self._reliable_spin = False
 
         # element symbol and atomic weight
         if name == "p":
@@ -208,6 +208,20 @@ class Nucleus:
             self.tau = _halflife_table.get_halflife(a=self.A, z=self.Z)
         except NotImplementedError:
             self.tau = None
+
+    @property
+    def reliable_spin(self):
+        return self._reliable_spin
+    
+    @reliable_spin.setter
+    def reliable_spin(self, value):
+        if self._reliable_spin != value:
+            self._reliable_spin = value
+            try:
+                self.spin_states = _spin_table.get_spin_states(a=self.A, z=self.Z, reliable=self.reliable_spin)
+            except NotImplementedError:
+                self.spin_states = None
+
 
     @classmethod
     def from_cache(cls, name, dummy=False):

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -17,7 +17,7 @@ _pynucastro_tabular_dir = _pynucastro_rates_dir/'tabular'
 # read the various tables with nuclear properties at the module-level
 _mass_table = MassTable()
 _halflife_table = HalfLifeTable()
-_spin_table = SpinTable(reliable=True)
+_spin_table = SpinTable(reliable=False)
 
 # read the partition function table once and store it at the module-level
 _pcollection = PartitionFunctionCollection(use_high_temperatures=True, use_set='frdm')

--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -212,7 +212,7 @@ class Nucleus:
     @property
     def reliable_spin(self):
         return self._reliable_spin
-    
+
     @reliable_spin.setter
     def reliable_spin(self, value):
         if self._reliable_spin != value:
@@ -221,7 +221,6 @@ class Nucleus:
                 self.spin_states = _spin_table.get_spin_states(a=self.A, z=self.Z, reliable=self.reliable_spin)
             except NotImplementedError:
                 self.spin_states = None
-
 
     @classmethod
     def from_cache(cls, name, dummy=False):

--- a/pynucastro/nucdata/spin_table.py
+++ b/pynucastro/nucdata/spin_table.py
@@ -60,16 +60,12 @@ class SpinTable:
         float
 
         """
-        if reliable:
-            try:
-                if self._reliability_table[a, z]:
-                    return self._spin_states[a, z]
-                else:
-                    raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not reliable enough for your specifications")
-            except KeyError as exc:
-                raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not available") from exc
-
         try:
-            return self._spin_states[a, z]
+            if not reliable:
+                return self._spin_states[a, z]
+            elif self._reliability_table[a, z]:
+                return self._spin_states[a, z]
+            else:
+                raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not reliable enough for your specifications")
         except KeyError as exc:
             raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not available") from exc

--- a/pynucastro/nucdata/spin_table.py
+++ b/pynucastro/nucdata/spin_table.py
@@ -61,11 +61,11 @@ class SpinTable:
 
         """
         try:
-            if not reliable:
+            if not reliable:                        # if you don't care about reliability
                 return self._spin_states[a, z]
-            elif self._reliability_table[a, z]:
+            elif self._reliability_table[a, z]:     # if you care about reliability and the spin is reliable
                 return self._spin_states[a, z]
-            else:
+            else:                                   # if you care about reliability and the spin is NOT reliable
                 raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not reliable enough for your specifications")
         except KeyError as exc:
             raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not available") from exc

--- a/pynucastro/nucdata/spin_table.py
+++ b/pynucastro/nucdata/spin_table.py
@@ -15,10 +15,9 @@ class SpinTable:
 
     """
 
-    def __init__(self, datafile: str | Path = None, reliable: bool = False) -> None:
+    def __init__(self, datafile: str | Path = None) -> None:
 
         self._spin_states = {}
-        self.reliable = reliable
 
         if datafile:
             self.datafile = Path(datafile)
@@ -38,13 +37,7 @@ class SpinTable:
                 A, Z, _, spin_states, experimental = line.strip().split()[:5]
                 A, Z, spin_states = int(A), int(Z), int(spin_states)
 
-                if self.reliable:
-                    if experimental == 's':
-                        self._spin_states[A, Z] = spin_states
-                    else:
-                        continue
-                else:
-                    self._spin_states[A, Z] = spin_states
+                self._spin_states[A, Z] = spin_states
 
     def get_spin_states(self, a: int, z: int) -> int:
         """Return the spin for a nucleus.

--- a/pynucastro/nucdata/spin_table.py
+++ b/pynucastro/nucdata/spin_table.py
@@ -18,6 +18,7 @@ class SpinTable:
     def __init__(self, datafile: str | Path = None) -> None:
 
         self._spin_states = {}
+        self._reliability_table = {}
 
         if datafile:
             self.datafile = Path(datafile)
@@ -38,8 +39,9 @@ class SpinTable:
                 A, Z, spin_states = int(A), int(Z), int(spin_states)
 
                 self._spin_states[A, Z] = spin_states
+                self._reliability_table[A, Z] = experimental == 's'
 
-    def get_spin_states(self, a: int, z: int) -> int:
+    def get_spin_states(self, a: int, z: int, reliable: bool = False) -> int:
         """Return the spin for a nucleus.
 
         Parameters
@@ -48,12 +50,25 @@ class SpinTable:
             Atomic weight
         z : int
             Atomic number
+        reliable : bool
+            setting this to True will only return spin states
+            for nuclei where the spin is known from strong
+            experimental arguments
 
         Returns
         -------
         float
 
         """
+        if reliable:
+            try:
+                if self._reliability_table[a, z]:
+                    return self._spin_states[a, z]
+                else:
+                    raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not reliable enough for your specifications")
+            except KeyError as exc:
+                raise NotImplementedError(f"nuclear spin data for A={a} and Z={z} not available") from exc
+
         try:
             return self._spin_states[a, z]
         except KeyError as exc:

--- a/pynucastro/nucdata/tests/test_nucleus.py
+++ b/pynucastro/nucdata/tests/test_nucleus.py
@@ -28,6 +28,8 @@ class TestNucleus:
         self.ne41 = Nucleus("ne41")
         self.ni61 = Nucleus("ni61")
         self.pb237 = Nucleus("pb237")
+        self.ag95 = Nucleus("ag95")
+        self.ru95 = Nucleus("ru95")
 
     def teardown_method(self):
         """ this is run after each test """
@@ -67,6 +69,24 @@ class TestNucleus:
         assert int(self.d.spin_states) == 3
         assert int(self.c12.spin_states) == 1
         assert int(self.ni56.spin_states) == 1
+
+    def test_change_spin(self):
+
+        # default is reliable_spin = False
+        assert int(self.ag95.spin_states) == 10
+        assert int(self.ru95.spin_states) == 6
+
+        self.ag95.reliable_spin = True
+        self.ru95.reliable_spin = True
+
+        assert int(self.ag95.spin_states) is None
+        assert int(self.ru95.spin_states) == 6
+
+        self.ag95.reliable_spin = False
+        self.ru95.reliable_spin = False
+
+        assert int(self.ag95.spin_states) == 10
+        assert int(self.ru95.spin_states) == 6
 
     def test_partition_low_temp(self):
 

--- a/pynucastro/nucdata/tests/test_nucleus.py
+++ b/pynucastro/nucdata/tests/test_nucleus.py
@@ -79,7 +79,7 @@ class TestNucleus:
         self.ag95.reliable_spin = True
         self.ru95.reliable_spin = True
 
-        assert int(self.ag95.spin_states) is None
+        assert self.ag95.spin_states is None
         assert int(self.ru95.spin_states) == 6
 
         self.ag95.reliable_spin = False

--- a/pynucastro/nucdata/tests/test_spin.py
+++ b/pynucastro/nucdata/tests/test_spin.py
@@ -27,6 +27,10 @@ class TestSpin:
         assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=True) == 2
         assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=True) == 1
         assert self.spintable_gs.get_spin_states(a=219, z=89, reliable=True) == 10
+        assert self.spintable_gs.get_spin_states(a=91, z=46, reliable=True) is None
+        assert self.spintable_gs.get_spin_states(a=275, z=107, reliable=True) is None
+        assert self.spintable_gs.get_spin_states(a=11, z=8, reliable=True) is None
+
         assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=False) == 2
         assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=False) == 1
         assert self.spintable_gs.get_spin_states(a=219, z=89, reliable=False) == 10

--- a/pynucastro/nucdata/tests/test_spin.py
+++ b/pynucastro/nucdata/tests/test_spin.py
@@ -1,4 +1,5 @@
 from pynucastro.nucdata import SpinTable
+import pytest
 
 
 class TestSpin:
@@ -27,9 +28,12 @@ class TestSpin:
         assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=True) == 2
         assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=True) == 1
         assert self.spintable_gs.get_spin_states(a=219, z=89, reliable=True) == 10
-        assert self.spintable_gs.get_spin_states(a=91, z=46, reliable=True) is None
-        assert self.spintable_gs.get_spin_states(a=275, z=107, reliable=True) is None
-        assert self.spintable_gs.get_spin_states(a=11, z=8, reliable=True) is None
+        with pytest.raises(NotImplementedError):
+            self.spintable_gs.get_spin_states(a=91, z=46, reliable=True)
+        with pytest.raises(NotImplementedError):
+            self.spintable_gs.get_spin_states(a=275, z=107, reliable=True)
+        with pytest.raises(NotImplementedError):
+            self.spintable_gs.get_spin_states(a=11, z=8, reliable=True)
 
         assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=False) == 2
         assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=False) == 1

--- a/pynucastro/nucdata/tests/test_spin.py
+++ b/pynucastro/nucdata/tests/test_spin.py
@@ -13,24 +13,23 @@ class TestSpin:
 
     def setup_method(self):
         """ this is run once for each class before any tests """
-        #Is import to remark that the spin state gs is unique.
-        #However, due to some experimental uncertainties two values
-        #are proposed.
 
-        self.spintable_gs_reliable = SpinTable(reliable=True)
-        self.spintable_gs_not_reliable = SpinTable(reliable=False)
+        self.spintable_gs = SpinTable()
 
     def teardown_method(self):
         """ this is run once for each class before any tests """
 
     def test_spin_table(self):
+        #Is important to remark that the spin state gs is unique.
+        #However, due to some experimental uncertainties two values
+        #are proposed.
 
-        assert self.spintable_gs_reliable.get_spin_states(a=1, z=0) == 2
-        assert self.spintable_gs_reliable.get_spin_states(a=14, z=4) == 1
-        assert self.spintable_gs_reliable.get_spin_states(a=219, z=89) == 10
-        assert self.spintable_gs_not_reliable.get_spin_states(a=1, z=0) == 2
-        assert self.spintable_gs_not_reliable.get_spin_states(a=14, z=4) == 1
-        assert self.spintable_gs_not_reliable.get_spin_states(a=219, z=89) == 10
-        assert self.spintable_gs_not_reliable.get_spin_states(a=91, z=46) == 8
-        assert self.spintable_gs_not_reliable.get_spin_states(a=275, z=107) == 6
-        assert self.spintable_gs_not_reliable.get_spin_states(a=11, z=8) == 4
+        assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=True) == 2
+        assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=True) == 1
+        assert self.spintable_gs.get_spin_states(a=219, z=89, reliable=True) == 10
+        assert self.spintable_gs.get_spin_states(a=1, z=0, reliable=False) == 2
+        assert self.spintable_gs.get_spin_states(a=14, z=4, reliable=False) == 1
+        assert self.spintable_gs.get_spin_states(a=219, z=89, reliable=False) == 10
+        assert self.spintable_gs.get_spin_states(a=91, z=46, reliable=False) == 8
+        assert self.spintable_gs.get_spin_states(a=275, z=107, reliable=False) == 6
+        assert self.spintable_gs.get_spin_states(a=11, z=8, reliable=False) == 4


### PR DESCRIPTION
Changed spin_table to store all spins internally, and to also store a table noting reliability of each spin. When requesting a spin, Nucleus specifies if it must be reliable or not, and spin_table either returns a spin or throws a NotImplementedError (that's the same as before). Nucleus can be chosen to be reliable through an attribute, and RateCollection can be chosen to be reliable through an initial parameter. 

Also added bits to the docs and the tests. It's a draft PR because I have one more test I want to add.

Recommend merging PR [#1115 ](https://github.com/pynucastro/pynucastro/pull/1115) first.