### PR TITLE
when doing the C++ network generation, disable some CPU features

### DIFF
--- a/.github/workflows/cxx-network.yml
+++ b/.github/workflows/cxx-network.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Regenerate he-burn-19am network
         run: |
           cd external/Microphysics/networks/he-burn/he-burn-19am
-          python he_burn_19am.py
+          NPY_DISABLE_CPU_FEATURES="AVX512F AVX512CD AVX512_SKX" python he_burn_19am.py
 
       - name: Compile burn_cell (he-burn-19am)
         run: |


### PR DESCRIPTION
this matches how we generate the nets with
Microphysics/networks/update_pynucastro_nets.py and will give better floating point consistency