### PR TITLE
Accomodate for windows drive letter convention

### DIFF
--- a/pynucastro/utils.py
+++ b/pynucastro/utils.py
@@ -8,7 +8,6 @@ import subprocess
 from importlib.metadata import Distribution
 from urllib.parse import urlparse
 
-
 from ._version import version
 
 


### PR DESCRIPTION
This PR adds a minor code block to pynucastro/utils.py to accomodate for windows drive letter convention when navigating paths. Does not affect functionality on other OS. 