### PR TITLE
eliminate multiple logs in table rate eval

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -376,7 +376,7 @@ class BaseCxxNetwork(ABC, RateCollection):
             for r in self.tabular_rates:
 
                 of.write(f'{idnt}tabular_evaluate({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data,\n')
-                of.write(f'{idnt}                 log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);\n')
+                of.write(f'{idnt}                 log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);\n')
 
                 of.write(f'{idnt}rate_eval.screened_rates(k_{r.cname()}) = rate;\n')
 
@@ -458,7 +458,7 @@ class BaseCxxNetwork(ABC, RateCollection):
             for r in self.tabular_rates:
 
                 of.write(f'{idnt}tabular_evaluate({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data,\n')
-                of.write(f'{idnt}                 log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);\n')
+                of.write(f'{idnt}                 log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);\n')
 
                 of.write(f'{idnt}rate_eval.screened_rates(k_{r.cname()}) = rate;\n')
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -387,7 +387,7 @@ AMREX_INLINE AMREX_GPU_HOST_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
                  const R& log_rhoy_table, const T& log_temp_table, const D& data,
-                 const amrex::Real log_rhoy, const amrex::Real log_temp,
+                 const amrex::Real log_rhoy, const amrex::Real log_temp, const amrex::Real temp,
                  amrex::Real& rate, amrex::Real& drate_dt, amrex::Real& edot_nu, amrex::Real& edot_gamma)
 {
     amrex::Array1D<amrex::Real, 1, num_vars+add_vars> entries;

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/table_rates.H
@@ -387,7 +387,7 @@ AMREX_INLINE AMREX_GPU_HOST_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
                  const R& log_rhoy_table, const T& log_temp_table, const D& data,
-                 const amrex::Real log_rhoy, const amrex::Real log_temp,
+                 const amrex::Real log_rhoy, const amrex::Real log_temp, const amrex::Real temp,
                  amrex::Real& rate, amrex::Real& drate_dt, amrex::Real& edot_nu, amrex::Real& edot_gamma)
 {
     amrex::Array1D<amrex::Real, 1, num_vars+add_vars> entries;

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -140,7 +140,7 @@ void evaluate_rates(const burn_t& state,
     amrex::Real log_rhoy = std::log10(rhoy);
 
     tabular_evaluate(j_Na23_Ne23_meta, j_Na23_Ne23_rhoy, j_Na23_Ne23_temp, j_Na23_Ne23_data,
-                     log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);
+                     log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_Na23_to_Ne23) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
         rate_eval.dscreened_rates_dT(k_Na23_to_Ne23) = drate_dt;
@@ -148,7 +148,7 @@ void evaluate_rates(const burn_t& state,
     rate_eval.enuc_weak += C::n_A * Y(Na23) * (edot_nu + edot_gamma);
 
     tabular_evaluate(j_Ne23_Na23_meta, j_Ne23_Na23_rhoy, j_Ne23_Na23_temp, j_Ne23_Na23_data,
-                     log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);
+                     log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_Ne23_to_Na23) = rate;
     if constexpr (std::is_same_v<T, rate_derivs_t>) {
         rate_eval.dscreened_rates_dT(k_Ne23_to_Na23) = drate_dt;
@@ -207,12 +207,12 @@ void get_ydot_weak(const burn_t& state,
     amrex::Real log_rhoy = std::log10(rhoy);
 
     tabular_evaluate(j_Na23_Ne23_meta, j_Na23_Ne23_rhoy, j_Na23_Ne23_temp, j_Na23_Ne23_data,
-                     log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);
+                     log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_Na23_to_Ne23) = rate;
     rate_eval.enuc_weak += C::n_A * Y(Na23) * (edot_nu + edot_gamma);
 
     tabular_evaluate(j_Ne23_Na23_meta, j_Ne23_Na23_rhoy, j_Ne23_Na23_temp, j_Ne23_Na23_data,
-                     log_rhoy, log_temp, rate, drate_dt, edot_nu, edot_gamma);
+                     log_rhoy, log_temp, state.T, rate, drate_dt, edot_nu, edot_gamma);
     rate_eval.screened_rates(k_Ne23_to_Na23) = rate;
     rate_eval.enuc_weak += C::n_A * Y(Ne23) * (edot_nu + edot_gamma);
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
@@ -397,7 +397,7 @@ AMREX_INLINE AMREX_GPU_HOST_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
                  const R& log_rhoy_table, const T& log_temp_table, const D& data,
-                 const amrex::Real log_rhoy, const amrex::Real log_temp,
+                 const amrex::Real log_rhoy, const amrex::Real log_temp, const amrex::Real temp,
                  amrex::Real& rate, amrex::Real& drate_dt, amrex::Real& edot_nu, amrex::Real& edot_gamma)
 {
     amrex::Array1D<amrex::Real, 1, num_vars+add_vars> entries;

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -388,7 +388,7 @@ AMREX_INLINE AMREX_GPU_HOST_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
                  const R& log_rhoy_table, const T& log_temp_table, const D& data,
-                 const amrex::Real log_rhoy, const amrex::Real log_temp,
+                 const amrex::Real log_rhoy, const amrex::Real log_temp, const amrex::Real temp,
                  amrex::Real& rate, amrex::Real& drate_dt, amrex::Real& edot_nu, amrex::Real& edot_gamma)
 {
     amrex::Array1D<amrex::Real, 1, num_vars+add_vars> entries;


### PR DESCRIPTION
we can compute log10(T) and log10(rhoy) once, and pass that through to the table evaluate.  For nets with lots of tabular rates, this should speed things up.