### PR TITLE
remove list_known_rates

### DIFF
--- a/pynucastro/__init__.py
+++ b/pynucastro/__init__.py
@@ -172,6 +172,6 @@ from pynucastro.rates import (ApproximateRate, DerivedRate, FFNLibrary,
                               LangankeLibrary, Library, ModifiedRate,
                               OdaLibrary, PruetFullerLibrary, Rate, RateFilter,
                               ReacLibLibrary, SuzukiLibrary, TabularLibrary,
-                              Tfactors, list_known_rates, load_rate)
+                              Tfactors, load_rate)
 from pynucastro.reduction import drgep, sens_analysis
 from pynucastro.screening import make_plasma_state, make_screen_factors

--- a/pynucastro/rates/__init__.py
+++ b/pynucastro/rates/__init__.py
@@ -8,7 +8,7 @@ from .files import RateFileError, _find_rate_file
 from .known_duplicates import find_duplicate_rates, is_allowed_dupe
 from .library import (FFNLibrary, LangankeLibrary, Library, OdaLibrary,
                       PruetFullerLibrary, RateFilter, ReacLibLibrary,
-                      SuzukiLibrary, TabularLibrary, list_known_rates)
+                      SuzukiLibrary, TabularLibrary)
 from .modified_rate import ModifiedRate
 from .rate import BaryonConservationError, Rate, RatePair, Tfactors
 from .reaclib_rate import ReacLibRate, SingleSet

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -11,32 +11,12 @@ from pathlib import Path
 
 from pynucastro.nucdata import Nucleus, UnsupportedNucleus
 from pynucastro.rates.derived_rate import DerivedRate
-from pynucastro.rates.files import (RateFileError, _find_rate_file,
-                                    get_rates_dir)
+from pynucastro.rates.files import _find_rate_file, get_rates_dir
 from pynucastro.rates.known_duplicates import (find_duplicate_rates,
                                                is_allowed_dupe)
 from pynucastro.rates.rate import Rate
 from pynucastro.rates.reaclib_rate import ReacLibRate
 from pynucastro.rates.tabular_rate import TabularRate
-
-
-def list_known_rates():
-    """Print a list of all of the rates found in the library."""
-
-    lib_path = Path(__file__).parents[1]/"library"
-
-    for _, _, filenames in walk(lib_path):
-        for f in filenames:
-            # skip over files that are not rate files
-            if Path(f).suffix in (".md", ".dat", ".py", "ipynb"):
-                continue
-            try:
-                lib = Library(f)
-            except (RateFileError, UnsupportedNucleus):
-                continue
-            print(f"{f:32} : ")
-            for r in lib.get_rates():
-                print(f"                                 : {r}")
 
 
 def _rate_name_to_nuc(name):


### PR DESCRIPTION
this is old and only works for single rate files
in a separate PR, I will add an uber-library that contains all rates, regardless of duplication