### PR TITLE
use amrex::Math::exp10(x) instead of std::pow(10, x)

### DIFF
--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/partition_functions.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
+#include <AMReX_Math.H>
 
 #include <tfactors.H>
 #include <fundamental_constants.H>
@@ -47,7 +48,7 @@ namespace part_fun {
             // find the PF
 
             amrex::Real log10_pf = pf_array(idx) + slope * (t9 - temp_array(idx));
-            pf = std::pow(10.0_rt, log10_pf);
+            pf = amrex::Math::exp10(log10_pf);
 
             // find the derivative (with respect to T, not T9)
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -7,7 +7,7 @@
 #include <string>
 
 #include <AMReX_Array.H>
-
+#include <AMReX_Math.H>
 #include <interp_tools.H>
 
 using namespace amrex::literals;
@@ -373,10 +373,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate       = std::pow(10.0_rt, entries(jtab_rate));
+    rate       = amrex::Math::exp10(entries(jtab_rate));
     drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
-    edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
-    edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
+    edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
+    edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }
 
 #endif

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/partition_functions.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
+#include <AMReX_Math.H>
 
 #include <tfactors.H>
 #include <fundamental_constants.H>
@@ -68,7 +69,7 @@ namespace part_fun {
             // find the PF
 
             amrex::Real log10_pf = pf_array(idx) + slope * (t9 - temp_array(idx));
-            pf = std::pow(10.0_rt, log10_pf);
+            pf = amrex::Math::exp10(log10_pf);
 
             // find the derivative (with respect to T, not T9)
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_derived_reference/table_rates.H
@@ -7,7 +7,7 @@
 #include <string>
 
 #include <AMReX_Array.H>
-
+#include <AMReX_Math.H>
 #include <interp_tools.H>
 
 using namespace amrex::literals;
@@ -373,10 +373,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate       = std::pow(10.0_rt, entries(jtab_rate));
+    rate       = amrex::Math::exp10(entries(jtab_rate));
     drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
-    edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
-    edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
+    edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
+    edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }
 
 #endif

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/partition_functions.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
+#include <AMReX_Math.H>
 
 #include <tfactors.H>
 #include <fundamental_constants.H>
@@ -47,7 +48,7 @@ namespace part_fun {
             // find the PF
 
             amrex::Real log10_pf = pf_array(idx) + slope * (t9 - temp_array(idx));
-            pf = std::pow(10.0_rt, log10_pf);
+            pf = amrex::Math::exp10(log10_pf);
 
             // find the derivative (with respect to T, not T9)
 

--- a/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/_amrexastro_cxx_reference/table_rates.H
@@ -7,7 +7,7 @@
 #include <string>
 
 #include <AMReX_Array.H>
-
+#include <AMReX_Math.H>
 #include <interp_tools.H>
 
 using namespace amrex::literals;
@@ -383,10 +383,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate       = std::pow(10.0_rt, entries(jtab_rate));
+    rate       = amrex::Math::exp10(entries(jtab_rate));
     drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
-    edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
-    edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
+    edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
+    edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }
 
 #endif

--- a/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/partition_functions.H.template
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
+#include <AMReX_Math.H>
 
 #include <tfactors.H>
 #include <fundamental_constants.H>
@@ -48,7 +49,7 @@ namespace part_fun {
             // find the PF
 
             amrex::Real log10_pf = pf_array(idx) + slope * (t9 - temp_array(idx));
-            pf = std::pow(10.0_rt, log10_pf);
+            pf = amrex::Math::exp10(log10_pf);
 
             // find the derivative (with respect to T, not T9)
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -7,7 +7,7 @@
 #include <string>
 
 #include <AMReX_Array.H>
-
+#include <AMReX_Math.H>
 #include <interp_tools.H>
 
 using namespace amrex::literals;
@@ -374,10 +374,10 @@ tabular_evaluate(const table_t& table_meta,
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
-    rate       = std::pow(10.0_rt, entries(jtab_rate));
+    rate       = amrex::Math::exp10(entries(jtab_rate));
     drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
-    edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
-    edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
+    edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
+    edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }
 
 #endif


### PR DESCRIPTION
on GPUs, this should be faster