### PR TITLE
Add 'neut' as an alias for neutron, to support MESA convention

### DIFF
--- a/pynucastro/nucdata/nucleus.py
+++ b/pynucastro/nucdata/nucleus.py
@@ -115,7 +115,7 @@ class Nucleus:
             self.short_spec_name = "he4"
             self.raw = "he4"
             self.caps_name = "He4"
-        elif name == "n" or name == 'neut':
+        elif name in ("n", 'neut'):
             self.el = "n"
             self.A = 1
             self.Z = 0


### PR DESCRIPTION
MESA log files use "neut" as the header for neutron mass fraction. If we add in "neut" as an alias for "n", we can use MESA header names to instantiate Nucleus objects without replacement.