### PR TITLE
bump the sphinx-book-theme to the github version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ sphinx-math-dollar
 sphinx-mdinclude
 sphinx-prompt
 sphinxcontrib-bibtex
-sphinx-book-theme
+git+https://github.com/executablebooks/sphinx-book-theme.git
 myst-nb
 jupyterlab-myst
 nbclient!=0.10.3


### PR DESCRIPTION
they haven't done a release in a while, and this allows the latest pydata-sphinx-theme which fixes a lot of accessibility issues