### PR TITLE
add a hash function to StarLibRate

### DIFF
--- a/pynucastro/rates/starlib_rate.py
+++ b/pynucastro/rates/starlib_rate.py
@@ -89,3 +89,6 @@ class StarLibRate(TemperatureTabularRate):
             return False
 
         return self.reactants == other.reactants and self.products == other.products
+
+    def __hash__(self):
+        return hash(self.__repr__())


### PR DESCRIPTION
turns out that python disables `__hash__` from inheritance if we define our own `__eq__`

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
