### PR TITLE
eliminate duplicate module / dir names in tests

### DIFF
--- a/pynucastro/networks/tests/test_approx_python_net.py
+++ b/pynucastro/networks/tests/test_approx_python_net.py
@@ -121,21 +121,21 @@ def He4_Mg24_to_Si28_removed(rate_eval, tf, log_scor=0.0):
         del sys.modules["app"]
 
     def test_to_composition(self, pynet):
-        pynet.write_network("app.py")
-        app = importlib.import_module("app")
+        pynet.write_network("app2.py")
+        app2 = importlib.import_module("app2")
 
         comp_orig = pyna.Composition(pynet.unique_nuclei)
         comp_orig.set_solar_like()
 
-        Y = np.zeros(app.nnuc)
+        Y = np.zeros(app2.nnuc)
         for nuc, molar_fraction in comp_orig.get_molar().items():
-            Y[app.names.index(nuc.caps_name)] = molar_fraction
-        comp_new = app.to_composition(Y)
+            Y[app2.names.index(nuc.caps_name)] = molar_fraction
+        comp_new = app2.to_composition(Y)
 
         assert comp_new.X == comp_orig.X
 
         # clean up generated files if the test passed
-        Path("app.py").unlink()
+        Path("app2.py").unlink()
         # remove imported module from cache
-        del app
-        del sys.modules["app"]
+        del app2
+        del sys.modules["app2"]

--- a/pynucastro/networks/tests/test_full_python_net.py
+++ b/pynucastro/networks/tests/test_full_python_net.py
@@ -28,13 +28,14 @@ class TestFullPythonNetwork:
 
     def test_write_network(self, fn, compare_network_files):
         """test the write_network function"""
+
         test_path = Path("_test_python/")
+        test_file = "network.py"
+
         # subdirectory of pynucastro/networks/tests/
         reference_path = Path("_python_reference/")
         # files that will be ignored if present in the generated directory
         skip_files = []
-
-        test_file = "network.py"
 
         # remove any previously generated files
         shutil.rmtree(test_path, ignore_errors=True)
@@ -47,13 +48,10 @@ class TestFullPythonNetwork:
 
     def test_ydots(self, fn):
 
-        test_path = Path("_test_python/")
-        test_file = "network.py"
+        test_file = "network2.py"
+        fn.write_network(outfile=test_file)
 
-        test_path.mkdir(parents=True, exist_ok=True)
-        fn.write_network(outfile=test_path/test_file)
-
-        import _test_python.network as net
+        import network2 as net
 
         X = np.zeros(net.nnuc)
         X[:] = 1.0 / net.nnuc


### PR DESCRIPTION
there are a few instances where we output a module several times in a test, each with the same name.  This now uses unique names. This should help with use eventually doing parallel tests.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
