### PR TITLE
split up the pip requirements

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -22,7 +22,9 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r ./requirements.txt
+        run: |
+          pip install -r ./requirements.txt
+          pip install -r ./requirements-docs.txt
 
       - name: Install codespell
         run: pip install codespell

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -32,7 +32,9 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r ./requirements.txt
+        run: |
+          pip install -r ./requirements.txt
+          pip install -r ./requirements-docs.txt
 
       - name: Install pynucastro
         run: pip install .

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,9 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r ./requirements.txt
+        run: |
+          pip install -r ./requirements.txt
+          pip install -r ./requirements-docs.txt
 
       - name: Install pynucastro
         run: pip install .

--- a/README.md
+++ b/README.md
@@ -206,10 +206,13 @@ To build the documentation or run the unit tests, `sphinx` and
 `pytest` are additionally required along with some supporting
 packages. See the included `requirements.txt` and
 `requirements-docs.txt` files for a list of these packages and
-versions. To install the packages from the requirements file, do: ```
-pip install -r requirements.txt ``` Is important to stress out that
-all the dependencies should be installed before `pynucastro`,
-otherwise the installation should be repeated.
+versions. To install the packages from the requirements file, do:
+```
+pip install -r requirements.txt -r requirements-docs.txt
+```
+It is important to stress out that all the dependencies should be
+installed before `pynucastro`, otherwise the installation should be
+repeated.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -204,15 +204,12 @@ pynucastro is supported on Python 3.10 or later and the following libraries:
 
 To build the documentation or run the unit tests, `sphinx` and
 `pytest` are additionally required along with some supporting
-packages. See the included `requirements.txt` file for a list of these
-packages and versions. To install the packages from the requirements
-file, do:
-```
-pip install -r requirements.txt
-```
-Is important to stress out that all the dependencies should be
-installed before `pynucastro`, otherwise the installation should be
-repeated.
+packages. See the included `requirements.txt` and
+`requirements-docs.txt` files for a list of these packages and
+versions. To install the packages from the requirements file, do: ```
+pip install -r requirements.txt ``` Is important to stress out that
+all the dependencies should be installed before `pynucastro`,
+otherwise the installation should be repeated.
 
 
 ## Contributing

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,16 @@
+# dependencies needed for building the docs
+ipykernel
+jinja2
+nbsphinx>=0.3.1
+numpydoc
+Sphinx
+sphinx-copybutton
+sphinx-math-dollar
+sphinx-mdinclude
+sphinx-prompt
+sphinxcontrib-bibtex
+sphinx-book-theme
+myst-nb
+jupyterlab-myst
+nbclient!=0.10.3
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,20 +14,3 @@ nbval>=0.9.0
 pytest-cov>=2.6.0
 pytest>=3.6
 pytest-xdist
-
-# docs
-ipykernel
-jinja2
-nbsphinx>=0.3.1
-numpydoc
-Sphinx
-sphinx-copybutton
-sphinx-math-dollar
-sphinx-mdinclude
-sphinx-prompt
-sphinxcontrib-bibtex
-git+https://github.com/executablebooks/sphinx-book-theme.git
-myst-nb
-jupyterlab-myst
-nbclient!=0.10.3
-


### PR DESCRIPTION
we don't need to install all the docs stuff for pytest so now the docs requirements are separate
also since sphinx-book-theme had a recent release, we don't need to install via git anymore

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
