### PR TITLE
allow no real rates when show_small_ydot is True

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -2160,30 +2160,33 @@ class RateCollection:
         real_edges = [(u, v) for u, v, e in sorted_edges if e["real"] == 1]
         real_weights = [e["weight"] for u, v, e in sorted_edges if e["real"] == 1]
 
-        if len(real_weights) == 0:
+        if len(real_weights) == 0 and not show_small_ydot:
             raise ValueError("No rates to show below ydot_cutoff_value.")
 
         if rate_ydots is None:
             edge_color = "C0"
         else:
             edge_color = real_weights
-        ww = np.array(real_weights)
-        min_weight = ww.min()
-        max_weight = ww.max()
-        dw = (max_weight - min_weight)/4
-        widths = np.ones_like(ww)
-        if dw > 0:
-            widths[ww > min_weight + dw] = 1.5
-            widths[ww > min_weight + 2*dw] = 2.5
-            widths[ww > min_weight + 3*dw] = 4
-        else:
-            widths *= 2
 
-        real_edges_lc = nx.draw_networkx_edges(G, G.position, width=list(widths),
-                                               edgelist=real_edges, edge_color=edge_color,
-                                               connectionstyle=connectionstyle,
-                                               node_size=node_size,
-                                               edge_cmap=plt.cm.viridis, ax=ax)
+        real_edges_lc = None
+        if len(real_weights) > 0:
+            ww = np.array(real_weights)
+            min_weight = ww.min()
+            max_weight = ww.max()
+            dw = (max_weight - min_weight)/4
+            widths = np.ones_like(ww)
+            if dw > 0:
+                widths[ww > min_weight + dw] = 1.5
+                widths[ww > min_weight + 2*dw] = 2.5
+                widths[ww > min_weight + 3*dw] = 4
+            else:
+                widths *= 2
+
+            real_edges_lc = nx.draw_networkx_edges(G, G.position, width=list(widths),
+                                                   edgelist=real_edges, edge_color=edge_color,
+                                                   connectionstyle=connectionstyle,
+                                                   node_size=node_size,
+                                                   edge_cmap=plt.cm.viridis, ax=ax)
 
         # highlight edges -- this is basically overplotting the edges we already drew
 
@@ -2234,7 +2237,7 @@ class RateCollection:
         if rotated:
             orientation = "horizontal"
 
-        if rate_ydots is not None:
+        if rate_ydots is not None and real_edges_lc is not None:
             pc = mpl.collections.PatchCollection(real_edges_lc, cmap=plt.cm.viridis)
             pc.set_array(real_weights)
             label = r"$\log_{10}(\mathrm{rate})$"


### PR DESCRIPTION
we currently abort with a ValueError if there are no rates to show, but if we set show_small_ydot = True, we can still draw the connections, just without any colorscale.  This allows us to visualize the network with a ipywidget interact() without crashing if rates drop below our threshold.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
