### PR TITLE
split the rate_t, approximate rates, and modified rates into headers

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -8,6 +8,7 @@ comprised of the rates that are passed in.
 import itertools
 import re
 import sys
+import textwrap
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -567,9 +568,11 @@ class BaseCxxNetwork(ABC, RateCollection):
             of.write(r.function_string_cxx(dtype=self.dtype, specifiers=self.function_specifier))
 
     def _modified_rate_functions(self, n_indent, of):
-        assert n_indent == 0, "function definitions must be at top level"
         for r in self.modified_rates:
-            of.write(r.function_string_cxx(dtype=self.dtype, specifiers=self.function_specifier))
+            fstr = r.function_string_cxx(dtype=self.dtype,
+                                         specifiers=self.function_specifier)
+            indented_fstr = textwrap.indent(fstr, self.indent * n_indent)
+            of.write(indented_fstr)
 
     def _derived_rate_functions(self, n_indent, of):
         assert n_indent == 0, "function definitions must be at top level"

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -102,8 +102,10 @@ class BaseCxxNetwork(ABC, RateCollection):
         self.ftags['<ydot_weak>'] = self._ydot_weak
         self.ftags['<jacnuc>'] = self._jacnuc
         self.ftags['<reaclib_rate_functions>'] = self._reaclib_rate_functions
+        self.ftags['<modified_rate_functions>'] = self._modified_rate_functions
         self.ftags['<rate_struct>'] = self._rate_struct
         self.ftags['<fill_reaclib_rates>'] = self._fill_reaclib_rates
+        self.ftags['<fill_modified_rates>'] = self._fill_modified_rates
         self.ftags['<fill_temp_tabular_rates>'] = self._fill_temp_tabular_rates
         self.ftags['<fill_starlib_rates>'] = self._fill_starlib_rates
         self.ftags['<derived_rate_functions>'] = self._derived_rate_functions
@@ -561,7 +563,12 @@ class BaseCxxNetwork(ABC, RateCollection):
 
     def _reaclib_rate_functions(self, n_indent, of):
         assert n_indent == 0, "function definitions must be at top level"
-        for r in self.reaclib_rates + self.modified_rates:
+        for r in self.reaclib_rates:
+            of.write(r.function_string_cxx(dtype=self.dtype, specifiers=self.function_specifier))
+
+    def _modified_rate_functions(self, n_indent, of):
+        assert n_indent == 0, "function definitions must be at top level"
+        for r in self.modified_rates:
             of.write(r.function_string_cxx(dtype=self.dtype, specifiers=self.function_specifier))
 
     def _derived_rate_functions(self, n_indent, of):
@@ -573,18 +580,18 @@ class BaseCxxNetwork(ABC, RateCollection):
         assert n_indent == 0, "function definitions must be at top level"
 
         of.write("struct rate_t {\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumRates>  screened_rates;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumRates>  screened_rates;\n")
         of.write("#ifdef SCREENING\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumScreenPairs>  log_screen;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumScreenPairs>  log_screen;\n")
         of.write("#endif\n")
         of.write(f"    {self.dtype} enuc_weak;\n")
         of.write("};\n\n")
         of.write("struct rate_derivs_t {\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumRates>  screened_rates;\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumRates>  dscreened_rates_dT;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumRates>  screened_rates;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumRates>  dscreened_rates_dT;\n")
         of.write("#ifdef SCREENING\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumScreenPairs>  log_screen;\n")
-        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, NumScreenPairs>  dlog_screen_dT;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumScreenPairs>  log_screen;\n")
+        of.write(f"    {self.array_namespace}Array1D<{self.dtype}, 1, Rates::NumScreenPairs>  dlog_screen_dT;\n")
         of.write("#endif\n")
         of.write(f"    {self.dtype} enuc_weak;\n")
         of.write("};\n\n")
@@ -638,10 +645,18 @@ class BaseCxxNetwork(ABC, RateCollection):
             of.write(f"{self.indent*n_indent}" + "}\n\n")
 
     def _fill_reaclib_rates(self, n_indent, of):
-        # note: modified_rates needs to be on the end here, since they
-        # likely will call the underlying reaclib rate for the actual
-        # rate evaluation
-        for r in self.reaclib_rates + self.modified_rates:
+        for r in self.reaclib_rates:
+            of.write(f"{self.indent*n_indent}" + "{\n")
+            self.write_screen_var(n_indent+1, of, r)
+            of.write(f"{self.indent*(n_indent+1)}rate_{r.fname}<do_T_derivatives>(tfactors, log_scor, dlog_scor_dT, rate, drate_dT);\n")
+            of.write(f"{self.indent*(n_indent+1)}rate_eval.screened_rates(k_{r.fname}) = rate;\n")
+            of.write(f"{self.indent*(n_indent+1)}if constexpr (std::is_same_v<T, rate_derivs_t>) {{\n")
+            of.write(f"{self.indent*(n_indent+1)}    rate_eval.dscreened_rates_dT(k_{r.fname}) = drate_dT;\n")
+            of.write(f"{self.indent*(n_indent+1)}}}\n")
+            of.write(f"{self.indent*n_indent}" + "}\n\n")
+
+    def _fill_modified_rates(self, n_indent, of):
+        for r in self.modified_rates:
             of.write(f"{self.indent*n_indent}" + "{\n")
             self.write_screen_var(n_indent+1, of, r)
             of.write(f"{self.indent*(n_indent+1)}rate_{r.fname}<do_T_derivatives>(tfactors, log_scor, dlog_scor_dT, rate, drate_dT);\n")

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/Make.package
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/Make.package
@@ -7,7 +7,10 @@ ifeq ($(USE_REACT),TRUE)
   CEXE_headers += interp_tools.H
   CEXE_headers += partition_functions.H
   CEXE_headers += actual_rhs.H
+  CEXE_headers += rate_type.H
   CEXE_headers += reaclib_rates.H
+  CEXE_headers += approximate_rates.H
+  CEXE_headers += modified_rates.H
   CEXE_headers += table_rates.H
   CEXE_headers += temperature_table_rates.H
   CEXE_headers += derived_rates.H

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -140,16 +140,19 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx
-    // rates and modified rates, since those may have ReacLibRate,
-    // TemperatureTabularRate, or DerivedRate as the underlying rate.
+    // fill modified rates next -- these can have ReacLib or
+    // TemperatureTabular/StarLib rates as the original rate
+    modified_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
+
+    // Calculate Derived Rates next. This should go last but before
+    // approx rates, since those may have ReacLibRate,
+    // TemperatureTabularRate / StarLibRate, or DerivedRate as the
+    // underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill modified and approximate rates
-
-    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
+    // Fill approximate rates
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -1,5 +1,5 @@
-#ifndef actual_rhs_H
-#define actual_rhs_H
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -15,7 +15,10 @@
 #ifdef NEUTRINOS
 #include <neutrino.H>
 #endif
+#include <rate_type.H>
 #include <reaclib_rates.H>
+#include <approximate_rates.H>
+#include <modified_rates.H>
 #include <table_rates.H>
 #include <temperature_table_rates.H>
 #include <derived_rates.H>
@@ -137,16 +140,20 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx rates.
+    // Calculate Derived Rates. This should go last but before approx
+    // rates and modified rates, since those may have ReacLibRate,
+    // TemperatureTabularRate, or DerivedRate as the underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill approximate rates
+    // Fill modified and approximate rates
+
+    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 
-    // Calculate tabular rates
+    // Calculate tabular weak rates
 
     [[maybe_unused]] amrex::Real rate, drate_dt, edot_nu, edot_gamma;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/approximate_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/approximate_rates.H
@@ -1,0 +1,131 @@
+#ifndef APPROXIMATE_RATES_H
+#define APPROXIMATE_RATES_H
+
+#include <AMReX.H>
+#include <AMReX_Print.H>
+
+#include <tfactors.H>
+#include <actual_network.H>
+#include <rate_type.H>
+
+using namespace Rates;
+using namespace Species;
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void rate_Mg24_He4_to_Si28_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
+
+    amrex::Real r_ag = rate_eval.screened_rates(k_He4_Mg24_to_Si28_reaclib);
+    amrex::Real r_ap = rate_eval.screened_rates(k_He4_Mg24_to_p_Al27_reaclib);
+    amrex::Real r_pg = rate_eval.screened_rates(k_p_Al27_to_Si28_reaclib);
+    amrex::Real r_pa = rate_eval.screened_rates(k_p_Al27_to_He4_Mg24_reaclib);
+    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
+    rate = r_ag + r_ap * r_pg * dd;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        amrex::Real drdT_ag = rate_eval.dscreened_rates_dT(k_He4_Mg24_to_Si28_reaclib);
+        amrex::Real drdT_ap = rate_eval.dscreened_rates_dT(k_He4_Mg24_to_p_Al27_reaclib);
+        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_Al27_to_Si28_reaclib);
+        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_Al27_to_He4_Mg24_reaclib);
+        drate_dT = drdT_ag + drdT_ap * r_pg * dd + r_ap * drdT_pg * dd - r_ap * r_pg * dd * dd * (drdT_pg + drdT_pa);
+    }
+}
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void rate_Si28_to_Mg24_He4_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
+
+    amrex::Real r_ga = rate_eval.screened_rates(k_Si28_to_He4_Mg24_reaclib);
+    amrex::Real r_pa = rate_eval.screened_rates(k_p_Al27_to_He4_Mg24_reaclib);
+    amrex::Real r_gp = rate_eval.screened_rates(k_Si28_to_p_Al27_reaclib);
+    amrex::Real r_pg = rate_eval.screened_rates(k_p_Al27_to_Si28_reaclib);
+    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
+    rate = r_ga + r_gp * r_pa * dd;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        amrex::Real drdT_ga = rate_eval.dscreened_rates_dT(k_Si28_to_He4_Mg24_reaclib);
+        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_Al27_to_He4_Mg24_reaclib);
+        amrex::Real drdT_gp = rate_eval.dscreened_rates_dT(k_Si28_to_p_Al27_reaclib);
+        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_Al27_to_Si28_reaclib);
+        drate_dT = drdT_ga + drdT_gp * r_pa * dd + r_gp * drdT_pa * dd - r_gp * r_pa * dd * dd * (drdT_pg + drdT_pa);
+    }
+}
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void rate_Si28_He4_to_S32_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
+
+    amrex::Real r_ag = rate_eval.screened_rates(k_He4_Si28_to_S32_reaclib);
+    amrex::Real r_ap = rate_eval.screened_rates(k_He4_Si28_to_p_P31_reaclib);
+    amrex::Real r_pg = rate_eval.screened_rates(k_p_P31_to_S32_reaclib);
+    amrex::Real r_pa = rate_eval.screened_rates(k_p_P31_to_He4_Si28_reaclib);
+    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
+    rate = r_ag + r_ap * r_pg * dd;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        amrex::Real drdT_ag = rate_eval.dscreened_rates_dT(k_He4_Si28_to_S32_reaclib);
+        amrex::Real drdT_ap = rate_eval.dscreened_rates_dT(k_He4_Si28_to_p_P31_reaclib);
+        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_P31_to_S32_reaclib);
+        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_P31_to_He4_Si28_reaclib);
+        drate_dT = drdT_ag + drdT_ap * r_pg * dd + r_ap * drdT_pg * dd - r_ap * r_pg * dd * dd * (drdT_pg + drdT_pa);
+    }
+}
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void rate_S32_to_Si28_He4_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
+
+    amrex::Real r_ga = rate_eval.screened_rates(k_S32_to_He4_Si28_reaclib);
+    amrex::Real r_pa = rate_eval.screened_rates(k_p_P31_to_He4_Si28_reaclib);
+    amrex::Real r_gp = rate_eval.screened_rates(k_S32_to_p_P31_reaclib);
+    amrex::Real r_pg = rate_eval.screened_rates(k_p_P31_to_S32_reaclib);
+    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
+    rate = r_ga + r_gp * r_pa * dd;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        amrex::Real drdT_ga = rate_eval.dscreened_rates_dT(k_S32_to_He4_Si28_reaclib);
+        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_P31_to_He4_Si28_reaclib);
+        amrex::Real drdT_gp = rate_eval.dscreened_rates_dT(k_S32_to_p_P31_reaclib);
+        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_P31_to_S32_reaclib);
+        drate_dT = drdT_ga + drdT_gp * r_pa * dd + r_gp * drdT_pa * dd - r_gp * r_pa * dd * dd * (drdT_pg + drdT_pa);
+    }
+}
+
+
+
+template <int do_T_derivatives, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
+                  [[maybe_unused]] const amrex::Real rho,
+                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
+                  [[maybe_unused]] T& rate_eval)
+{
+
+    [[maybe_unused]] amrex::Real rate{};
+    [[maybe_unused]] amrex::Real drate_dT{};
+
+    rate_Mg24_He4_to_Si28_approx<T>(rate_eval, rate, drate_dT);
+    rate_eval.screened_rates(k_Mg24_He4_to_Si28_approx) = rate;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        rate_eval.dscreened_rates_dT(k_Mg24_He4_to_Si28_approx) = drate_dT;
+    }
+
+    rate_Si28_to_Mg24_He4_approx<T>(rate_eval, rate, drate_dT);
+    rate_eval.screened_rates(k_Si28_to_Mg24_He4_approx) = rate;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        rate_eval.dscreened_rates_dT(k_Si28_to_Mg24_He4_approx) = drate_dT;
+    }
+
+    rate_Si28_He4_to_S32_approx<T>(rate_eval, rate, drate_dT);
+    rate_eval.screened_rates(k_Si28_He4_to_S32_approx) = rate;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        rate_eval.dscreened_rates_dT(k_Si28_He4_to_S32_approx) = drate_dT;
+    }
+
+    rate_S32_to_Si28_He4_approx<T>(rate_eval, rate, drate_dT);
+    rate_eval.screened_rates(k_S32_to_Si28_He4_approx) = rate;
+    if constexpr (std::is_same_v<T, rate_derivs_t>) {
+        rate_eval.dscreened_rates_dT(k_S32_to_Si28_He4_approx) = drate_dT;
+    }
+
+
+}
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
@@ -7,21 +7,24 @@
 #include <tfactors.H>
 #include <actual_network.H>
 #include <rate_type.H>
+#include <temperature_table_rates.H>
+#include <reaclib_rates.H>
 
-using namespace Rates;
-using namespace Species;
+namespace modified_rates {
 
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_modified_rates(const tf_t& tfactors, T& rate_eval)
-{
-
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    using namespace temp_tabular;
 
 
+    template <int do_T_derivatives, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void
+    fill_rates(const tf_t& tfactors, T& rate_eval)
+    {
+
+        amrex::Real rate;
+        amrex::Real drate_dT;
+
+
+    }
 }
-
 #endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
@@ -1,5 +1,5 @@
-#ifndef REACLIB_RATES_H
-#define REACLIB_RATES_H
+#ifndef MODIFIED_RATES_H
+#define MODIFIED_RATES_H
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -11,18 +11,16 @@
 using namespace Rates;
 using namespace Species;
 
-<reaclib_rate_functions>(0)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_modified_rates(const tf_t& tfactors, T& rate_eval)
 {
 
     amrex::Real rate;
     amrex::Real drate_dT;
 
-    <fill_reaclib_rates>(1)
 
 }
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/modified_rates.H
@@ -18,11 +18,12 @@ namespace modified_rates {
     template <int do_T_derivatives, typename T>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void
-    fill_rates(const tf_t& tfactors, T& rate_eval)
+    fill_rates([[maybe_unused]] const tf_t& tfactors,
+               [[maybe_unused]] T& rate_eval)
     {
 
-        amrex::Real rate;
-        amrex::Real drate_dT;
+        [[maybe_unused]] amrex::Real rate;
+        [[maybe_unused]] amrex::Real drate_dT;
 
 
     }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/rate_type.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/rate_type.H
@@ -1,0 +1,25 @@
+#ifndef NET_RATE_TYPE_H
+#define NET_RATE_TYPE_H
+
+#include <actual_network.H>
+
+struct rate_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+#endif
+    amrex::Real enuc_weak;
+};
+
+struct rate_derivs_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  dscreened_rates_dT;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
+#endif
+    amrex::Real enuc_weak;
+};
+
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
@@ -821,7 +821,8 @@ void rate_p_P31_to_He4_Si28_reaclib(const tf_t& tfactors, const amrex::Real log_
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_reaclib_rates([[maybe_unused]] const tf_t& tfactors,
+                   [[maybe_unused]] T& rate_eval)
 {
 
     [[maybe_unused]] amrex::Real rate;

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
@@ -6,28 +6,10 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
+#include <rate_type.H>
 
 using namespace Rates;
 using namespace Species;
-
-struct rate_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-#endif
-    amrex::Real enuc_weak;
-};
-
-struct rate_derivs_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-    amrex::Array1D<amrex::Real, 1, NumRates>  dscreened_rates_dT;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  dlog_screen_dT;
-#endif
-    amrex::Real enuc_weak;
-};
-
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -836,83 +818,6 @@ void rate_p_P31_to_He4_Si28_reaclib(const tf_t& tfactors, const amrex::Real log_
 }
 
 
-template <typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_Mg24_He4_to_Si28_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
-
-    amrex::Real r_ag = rate_eval.screened_rates(k_He4_Mg24_to_Si28_reaclib);
-    amrex::Real r_ap = rate_eval.screened_rates(k_He4_Mg24_to_p_Al27_reaclib);
-    amrex::Real r_pg = rate_eval.screened_rates(k_p_Al27_to_Si28_reaclib);
-    amrex::Real r_pa = rate_eval.screened_rates(k_p_Al27_to_He4_Mg24_reaclib);
-    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
-    rate = r_ag + r_ap * r_pg * dd;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        amrex::Real drdT_ag = rate_eval.dscreened_rates_dT(k_He4_Mg24_to_Si28_reaclib);
-        amrex::Real drdT_ap = rate_eval.dscreened_rates_dT(k_He4_Mg24_to_p_Al27_reaclib);
-        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_Al27_to_Si28_reaclib);
-        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_Al27_to_He4_Mg24_reaclib);
-        drate_dT = drdT_ag + drdT_ap * r_pg * dd + r_ap * drdT_pg * dd - r_ap * r_pg * dd * dd * (drdT_pg + drdT_pa);
-    }
-}
-
-template <typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_Si28_to_Mg24_He4_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
-
-    amrex::Real r_ga = rate_eval.screened_rates(k_Si28_to_He4_Mg24_reaclib);
-    amrex::Real r_pa = rate_eval.screened_rates(k_p_Al27_to_He4_Mg24_reaclib);
-    amrex::Real r_gp = rate_eval.screened_rates(k_Si28_to_p_Al27_reaclib);
-    amrex::Real r_pg = rate_eval.screened_rates(k_p_Al27_to_Si28_reaclib);
-    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
-    rate = r_ga + r_gp * r_pa * dd;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        amrex::Real drdT_ga = rate_eval.dscreened_rates_dT(k_Si28_to_He4_Mg24_reaclib);
-        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_Al27_to_He4_Mg24_reaclib);
-        amrex::Real drdT_gp = rate_eval.dscreened_rates_dT(k_Si28_to_p_Al27_reaclib);
-        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_Al27_to_Si28_reaclib);
-        drate_dT = drdT_ga + drdT_gp * r_pa * dd + r_gp * drdT_pa * dd - r_gp * r_pa * dd * dd * (drdT_pg + drdT_pa);
-    }
-}
-
-template <typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_Si28_He4_to_S32_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
-
-    amrex::Real r_ag = rate_eval.screened_rates(k_He4_Si28_to_S32_reaclib);
-    amrex::Real r_ap = rate_eval.screened_rates(k_He4_Si28_to_p_P31_reaclib);
-    amrex::Real r_pg = rate_eval.screened_rates(k_p_P31_to_S32_reaclib);
-    amrex::Real r_pa = rate_eval.screened_rates(k_p_P31_to_He4_Si28_reaclib);
-    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
-    rate = r_ag + r_ap * r_pg * dd;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        amrex::Real drdT_ag = rate_eval.dscreened_rates_dT(k_He4_Si28_to_S32_reaclib);
-        amrex::Real drdT_ap = rate_eval.dscreened_rates_dT(k_He4_Si28_to_p_P31_reaclib);
-        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_P31_to_S32_reaclib);
-        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_P31_to_He4_Si28_reaclib);
-        drate_dT = drdT_ag + drdT_ap * r_pg * dd + r_ap * drdT_pg * dd - r_ap * r_pg * dd * dd * (drdT_pg + drdT_pa);
-    }
-}
-
-template <typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void rate_S32_to_Si28_He4_approx(const T& rate_eval, amrex::Real& rate, amrex::Real& drate_dT) {
-
-    amrex::Real r_ga = rate_eval.screened_rates(k_S32_to_He4_Si28_reaclib);
-    amrex::Real r_pa = rate_eval.screened_rates(k_p_P31_to_He4_Si28_reaclib);
-    amrex::Real r_gp = rate_eval.screened_rates(k_S32_to_p_P31_reaclib);
-    amrex::Real r_pg = rate_eval.screened_rates(k_p_P31_to_S32_reaclib);
-    amrex::Real dd = 1.0_rt / (r_pg + r_pa);
-    rate = r_ga + r_gp * r_pa * dd;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        amrex::Real drdT_ga = rate_eval.dscreened_rates_dT(k_S32_to_He4_Si28_reaclib);
-        amrex::Real drdT_pa = rate_eval.dscreened_rates_dT(k_p_P31_to_He4_Si28_reaclib);
-        amrex::Real drdT_gp = rate_eval.dscreened_rates_dT(k_S32_to_p_P31_reaclib);
-        amrex::Real drdT_pg = rate_eval.dscreened_rates_dT(k_p_P31_to_S32_reaclib);
-        drate_dT = drdT_ga + drdT_gp * r_pa * dd + r_gp * drdT_pa * dd - r_gp * r_pa * dd * dd * (drdT_pg + drdT_pa);
-    }
-}
-
-
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
@@ -1088,45 +993,6 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
         if constexpr (std::is_same_v<T, rate_derivs_t>) {
             rate_eval.dscreened_rates_dT(k_p_P31_to_He4_Si28_reaclib) = drate_dT;
         }
-    }
-
-
-}
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
-                  [[maybe_unused]] const amrex::Real rho,
-                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-                  [[maybe_unused]] T& rate_eval)
-{
-
-    [[maybe_unused]] amrex::Real rate{};
-    [[maybe_unused]] amrex::Real drate_dT{};
-
-    rate_Mg24_He4_to_Si28_approx<T>(rate_eval, rate, drate_dT);
-    rate_eval.screened_rates(k_Mg24_He4_to_Si28_approx) = rate;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        rate_eval.dscreened_rates_dT(k_Mg24_He4_to_Si28_approx) = drate_dT;
-    }
-
-    rate_Si28_to_Mg24_He4_approx<T>(rate_eval, rate, drate_dT);
-    rate_eval.screened_rates(k_Si28_to_Mg24_He4_approx) = rate;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        rate_eval.dscreened_rates_dT(k_Si28_to_Mg24_He4_approx) = drate_dT;
-    }
-
-    rate_Si28_He4_to_S32_approx<T>(rate_eval, rate, drate_dT);
-    rate_eval.screened_rates(k_Si28_He4_to_S32_approx) = rate;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        rate_eval.dscreened_rates_dT(k_Si28_He4_to_S32_approx) = drate_dT;
-    }
-
-    rate_S32_to_Si28_He4_approx<T>(rate_eval, rate, drate_dT);
-    rate_eval.screened_rates(k_S32_to_Si28_He4_approx) = rate;
-    if constexpr (std::is_same_v<T, rate_derivs_t>) {
-        rate_eval.dscreened_rates_dT(k_S32_to_Si28_He4_approx) = drate_dT;
     }
 
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/reaclib_rates.H
@@ -824,8 +824,8 @@ void
 fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 {
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    [[maybe_unused]] amrex::Real rate;
+    [[maybe_unused]] amrex::Real drate_dT;
 
     {
         amrex::Real log_scor {0.0_rt};

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/temperature_table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/temperature_table_rates.H
@@ -5,7 +5,7 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
-
+#include <interp_tools.H>
 
 using namespace amrex::literals;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/Make.package
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/Make.package
@@ -7,7 +7,10 @@ ifeq ($(USE_REACT),TRUE)
   CEXE_headers += interp_tools.H
   CEXE_headers += partition_functions.H
   CEXE_headers += actual_rhs.H
+  CEXE_headers += rate_type.H
   CEXE_headers += reaclib_rates.H
+  CEXE_headers += approximate_rates.H
+  CEXE_headers += modified_rates.H
   CEXE_headers += table_rates.H
   CEXE_headers += temperature_table_rates.H
   CEXE_headers += derived_rates.H

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -1,5 +1,5 @@
-#ifndef actual_rhs_H
-#define actual_rhs_H
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -15,7 +15,10 @@
 #ifdef NEUTRINOS
 #include <neutrino.H>
 #endif
+#include <rate_type.H>
 #include <reaclib_rates.H>
+#include <approximate_rates.H>
+#include <modified_rates.H>
 #include <table_rates.H>
 #include <temperature_table_rates.H>
 #include <derived_rates.H>
@@ -117,16 +120,20 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx rates.
+    // Calculate Derived Rates. This should go last but before approx
+    // rates and modified rates, since those may have ReacLibRate,
+    // TemperatureTabularRate, or DerivedRate as the underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill approximate rates
+    // Fill modified and approximate rates
+
+    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 
-    // Calculate tabular rates
+    // Calculate tabular weak rates
 
     [[maybe_unused]] amrex::Real rate, drate_dt, edot_nu, edot_gamma;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -120,16 +120,19 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx
-    // rates and modified rates, since those may have ReacLibRate,
-    // TemperatureTabularRate, or DerivedRate as the underlying rate.
+    // fill modified rates next -- these can have ReacLib or
+    // TemperatureTabular/StarLib rates as the original rate
+    modified_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
+
+    // Calculate Derived Rates next. This should go last but before
+    // approx rates, since those may have ReacLibRate,
+    // TemperatureTabularRate / StarLibRate, or DerivedRate as the
+    // underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill modified and approximate rates
-
-    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
+    // Fill approximate rates
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/approximate_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/approximate_rates.H
@@ -1,0 +1,31 @@
+#ifndef APPROXIMATE_RATES_H
+#define APPROXIMATE_RATES_H
+
+#include <AMReX.H>
+#include <AMReX_Print.H>
+
+#include <tfactors.H>
+#include <actual_network.H>
+#include <rate_type.H>
+
+using namespace Rates;
+using namespace Species;
+
+
+
+template <int do_T_derivatives, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
+                  [[maybe_unused]] const amrex::Real rho,
+                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
+                  [[maybe_unused]] T& rate_eval)
+{
+
+    [[maybe_unused]] amrex::Real rate{};
+    [[maybe_unused]] amrex::Real drate_dT{};
+
+
+}
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
@@ -7,21 +7,24 @@
 #include <tfactors.H>
 #include <actual_network.H>
 #include <rate_type.H>
+#include <temperature_table_rates.H>
+#include <reaclib_rates.H>
 
-using namespace Rates;
-using namespace Species;
+namespace modified_rates {
 
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_modified_rates(const tf_t& tfactors, T& rate_eval)
-{
-
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    using namespace temp_tabular;
 
 
+    template <int do_T_derivatives, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void
+    fill_rates(const tf_t& tfactors, T& rate_eval)
+    {
+
+        amrex::Real rate;
+        amrex::Real drate_dT;
+
+
+    }
 }
-
 #endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
@@ -1,5 +1,5 @@
-#ifndef REACLIB_RATES_H
-#define REACLIB_RATES_H
+#ifndef MODIFIED_RATES_H
+#define MODIFIED_RATES_H
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -11,18 +11,16 @@
 using namespace Rates;
 using namespace Species;
 
-<reaclib_rate_functions>(0)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_modified_rates(const tf_t& tfactors, T& rate_eval)
 {
 
     amrex::Real rate;
     amrex::Real drate_dT;
 
-    <fill_reaclib_rates>(1)
 
 }
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/modified_rates.H
@@ -18,11 +18,12 @@ namespace modified_rates {
     template <int do_T_derivatives, typename T>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void
-    fill_rates(const tf_t& tfactors, T& rate_eval)
+    fill_rates([[maybe_unused]] const tf_t& tfactors,
+               [[maybe_unused]] T& rate_eval)
     {
 
-        amrex::Real rate;
-        amrex::Real drate_dT;
+        [[maybe_unused]] amrex::Real rate;
+        [[maybe_unused]] amrex::Real drate_dT;
 
 
     }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/rate_type.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/rate_type.H
@@ -1,0 +1,25 @@
+#ifndef NET_RATE_TYPE_H
+#define NET_RATE_TYPE_H
+
+#include <actual_network.H>
+
+struct rate_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+#endif
+    amrex::Real enuc_weak;
+};
+
+struct rate_derivs_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  dscreened_rates_dT;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
+#endif
+    amrex::Real enuc_weak;
+};
+
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
@@ -126,8 +126,8 @@ void
 fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 {
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    [[maybe_unused]] amrex::Real rate;
+    [[maybe_unused]] amrex::Real drate_dT;
 
     {
         amrex::Real log_scor {0.0_rt};

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
@@ -123,7 +123,8 @@ void rate_He4_Fe52_to_p_Co55_reaclib(const tf_t& tfactors, const amrex::Real log
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_reaclib_rates([[maybe_unused]] const tf_t& tfactors,
+                   [[maybe_unused]] T& rate_eval)
 {
 
     [[maybe_unused]] amrex::Real rate;

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/reaclib_rates.H
@@ -6,28 +6,10 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
+#include <rate_type.H>
 
 using namespace Rates;
 using namespace Species;
-
-struct rate_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-#endif
-    amrex::Real enuc_weak;
-};
-
-struct rate_derivs_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-    amrex::Array1D<amrex::Real, 1, NumRates>  dscreened_rates_dT;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  dlog_screen_dT;
-#endif
-    amrex::Real enuc_weak;
-};
-
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -138,7 +120,6 @@ void rate_He4_Fe52_to_p_Co55_reaclib(const tf_t& tfactors, const amrex::Real log
 }
 
 
-
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
@@ -195,21 +176,6 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
             rate_eval.dscreened_rates_dT(k_He4_Fe52_to_p_Co55_reaclib) = drate_dT;
         }
     }
-
-
-}
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
-                  [[maybe_unused]] const amrex::Real rho,
-                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-                  [[maybe_unused]] T& rate_eval)
-{
-
-    [[maybe_unused]] amrex::Real rate{};
-    [[maybe_unused]] amrex::Real drate_dT{};
 
 
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/temperature_table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/temperature_table_rates.H
@@ -5,7 +5,7 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
-
+#include <interp_tools.H>
 
 using namespace amrex::literals;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/Make.package
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/Make.package
@@ -7,7 +7,10 @@ ifeq ($(USE_REACT),TRUE)
   CEXE_headers += interp_tools.H
   CEXE_headers += partition_functions.H
   CEXE_headers += actual_rhs.H
+  CEXE_headers += rate_type.H
   CEXE_headers += reaclib_rates.H
+  CEXE_headers += approximate_rates.H
+  CEXE_headers += modified_rates.H
   CEXE_headers += table_rates.H
   CEXE_headers += temperature_table_rates.H
   CEXE_headers += derived_rates.H

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -1,5 +1,5 @@
-#ifndef actual_rhs_H
-#define actual_rhs_H
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -15,7 +15,10 @@
 #ifdef NEUTRINOS
 #include <neutrino.H>
 #endif
+#include <rate_type.H>
 #include <reaclib_rates.H>
+#include <approximate_rates.H>
+#include <modified_rates.H>
 #include <table_rates.H>
 #include <temperature_table_rates.H>
 #include <derived_rates.H>
@@ -117,16 +120,20 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx rates.
+    // Calculate Derived Rates. This should go last but before approx
+    // rates and modified rates, since those may have ReacLibRate,
+    // TemperatureTabularRate, or DerivedRate as the underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill approximate rates
+    // Fill modified and approximate rates
+
+    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 
-    // Calculate tabular rates
+    // Calculate tabular weak rates
 
     [[maybe_unused]] amrex::Real rate, drate_dt, edot_nu, edot_gamma;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -120,16 +120,19 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx
-    // rates and modified rates, since those may have ReacLibRate,
-    // TemperatureTabularRate, or DerivedRate as the underlying rate.
+    // fill modified rates next -- these can have ReacLib or
+    // TemperatureTabular/StarLib rates as the original rate
+    modified_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
+
+    // Calculate Derived Rates next. This should go last but before
+    // approx rates, since those may have ReacLibRate,
+    // TemperatureTabularRate / StarLibRate, or DerivedRate as the
+    // underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill modified and approximate rates
-
-    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
+    // Fill approximate rates
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/approximate_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/approximate_rates.H
@@ -1,0 +1,31 @@
+#ifndef APPROXIMATE_RATES_H
+#define APPROXIMATE_RATES_H
+
+#include <AMReX.H>
+#include <AMReX_Print.H>
+
+#include <tfactors.H>
+#include <actual_network.H>
+#include <rate_type.H>
+
+using namespace Rates;
+using namespace Species;
+
+
+
+template <int do_T_derivatives, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
+                  [[maybe_unused]] const amrex::Real rho,
+                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
+                  [[maybe_unused]] T& rate_eval)
+{
+
+    [[maybe_unused]] amrex::Real rate{};
+    [[maybe_unused]] amrex::Real drate_dT{};
+
+
+}
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
@@ -7,21 +7,24 @@
 #include <tfactors.H>
 #include <actual_network.H>
 #include <rate_type.H>
+#include <temperature_table_rates.H>
+#include <reaclib_rates.H>
 
-using namespace Rates;
-using namespace Species;
+namespace modified_rates {
 
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_modified_rates(const tf_t& tfactors, T& rate_eval)
-{
-
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    using namespace temp_tabular;
 
 
+    template <int do_T_derivatives, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void
+    fill_rates(const tf_t& tfactors, T& rate_eval)
+    {
+
+        amrex::Real rate;
+        amrex::Real drate_dT;
+
+
+    }
 }
-
 #endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
@@ -1,5 +1,5 @@
-#ifndef REACLIB_RATES_H
-#define REACLIB_RATES_H
+#ifndef MODIFIED_RATES_H
+#define MODIFIED_RATES_H
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -11,18 +11,16 @@
 using namespace Rates;
 using namespace Species;
 
-<reaclib_rate_functions>(0)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_modified_rates(const tf_t& tfactors, T& rate_eval)
 {
 
     amrex::Real rate;
     amrex::Real drate_dT;
 
-    <fill_reaclib_rates>(1)
 
 }
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/modified_rates.H
@@ -18,11 +18,12 @@ namespace modified_rates {
     template <int do_T_derivatives, typename T>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void
-    fill_rates(const tf_t& tfactors, T& rate_eval)
+    fill_rates([[maybe_unused]] const tf_t& tfactors,
+               [[maybe_unused]] T& rate_eval)
     {
 
-        amrex::Real rate;
-        amrex::Real drate_dT;
+        [[maybe_unused]] amrex::Real rate;
+        [[maybe_unused]] amrex::Real drate_dT;
 
 
     }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/rate_type.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/rate_type.H
@@ -1,0 +1,25 @@
+#ifndef NET_RATE_TYPE_H
+#define NET_RATE_TYPE_H
+
+#include <actual_network.H>
+
+struct rate_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+#endif
+    amrex::Real enuc_weak;
+};
+
+struct rate_derivs_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  dscreened_rates_dT;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
+#endif
+    amrex::Real enuc_weak;
+};
+
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
@@ -218,8 +218,8 @@ void
 fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 {
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    [[maybe_unused]] amrex::Real rate;
+    [[maybe_unused]] amrex::Real drate_dT;
 
     {
         amrex::Real log_scor {0.0_rt};

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
@@ -6,28 +6,10 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
+#include <rate_type.H>
 
 using namespace Rates;
 using namespace Species;
-
-struct rate_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-#endif
-    amrex::Real enuc_weak;
-};
-
-struct rate_derivs_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-    amrex::Array1D<amrex::Real, 1, NumRates>  dscreened_rates_dT;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  dlog_screen_dT;
-#endif
-    amrex::Real enuc_weak;
-};
-
 
 template <int do_T_derivatives>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -230,7 +212,6 @@ void rate_n_to_p_reaclib(const tf_t& tfactors, const amrex::Real log_scor, const
 }
 
 
-
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
@@ -313,21 +294,6 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
             rate_eval.dscreened_rates_dT(k_n_to_p_reaclib) = drate_dT;
         }
     }
-
-
-}
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
-                  [[maybe_unused]] const amrex::Real rho,
-                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-                  [[maybe_unused]] T& rate_eval)
-{
-
-    [[maybe_unused]] amrex::Real rate{};
-    [[maybe_unused]] amrex::Real drate_dT{};
 
 
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/reaclib_rates.H
@@ -215,7 +215,8 @@ void rate_n_to_p_reaclib(const tf_t& tfactors, const amrex::Real log_scor, const
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_reaclib_rates([[maybe_unused]] const tf_t& tfactors,
+                   [[maybe_unused]] T& rate_eval)
 {
 
     [[maybe_unused]] amrex::Real rate;

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/temperature_table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/temperature_table_rates.H
@@ -5,7 +5,7 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
-
+#include <interp_tools.H>
 
 using namespace amrex::literals;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/Make.package
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/Make.package
@@ -7,7 +7,10 @@ ifeq ($(USE_REACT),TRUE)
   CEXE_headers += interp_tools.H
   CEXE_headers += partition_functions.H
   CEXE_headers += actual_rhs.H
+  CEXE_headers += rate_type.H
   CEXE_headers += reaclib_rates.H
+  CEXE_headers += approximate_rates.H
+  CEXE_headers += modified_rates.H
   CEXE_headers += table_rates.H
   CEXE_headers += temperature_table_rates.H
   CEXE_headers += derived_rates.H

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
@@ -1,5 +1,5 @@
-#ifndef actual_rhs_H
-#define actual_rhs_H
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -15,7 +15,10 @@
 #ifdef NEUTRINOS
 #include <neutrino.H>
 #endif
+#include <rate_type.H>
 #include <reaclib_rates.H>
+#include <approximate_rates.H>
+#include <modified_rates.H>
 #include <table_rates.H>
 #include <temperature_table_rates.H>
 #include <derived_rates.H>
@@ -107,16 +110,20 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx rates.
+    // Calculate Derived Rates. This should go last but before approx
+    // rates and modified rates, since those may have ReacLibRate,
+    // TemperatureTabularRate, or DerivedRate as the underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill approximate rates
+    // Fill modified and approximate rates
+
+    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 
-    // Calculate tabular rates
+    // Calculate tabular weak rates
 
     [[maybe_unused]] amrex::Real rate, drate_dt, edot_nu, edot_gamma;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
@@ -110,16 +110,19 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx
-    // rates and modified rates, since those may have ReacLibRate,
-    // TemperatureTabularRate, or DerivedRate as the underlying rate.
+    // fill modified rates next -- these can have ReacLib or
+    // TemperatureTabular/StarLib rates as the original rate
+    modified_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
+
+    // Calculate Derived Rates next. This should go last but before
+    // approx rates, since those may have ReacLibRate,
+    // TemperatureTabularRate / StarLibRate, or DerivedRate as the
+    // underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
 
-    // Fill modified and approximate rates
-
-    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
+    // Fill approximate rates
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/approximate_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/approximate_rates.H
@@ -1,0 +1,31 @@
+#ifndef APPROXIMATE_RATES_H
+#define APPROXIMATE_RATES_H
+
+#include <AMReX.H>
+#include <AMReX_Print.H>
+
+#include <tfactors.H>
+#include <actual_network.H>
+#include <rate_type.H>
+
+using namespace Rates;
+using namespace Species;
+
+
+
+template <int do_T_derivatives, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
+                  [[maybe_unused]] const amrex::Real rho,
+                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
+                  [[maybe_unused]] T& rate_eval)
+{
+
+    [[maybe_unused]] amrex::Real rate{};
+    [[maybe_unused]] amrex::Real drate_dT{};
+
+
+}
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
@@ -7,21 +7,24 @@
 #include <tfactors.H>
 #include <actual_network.H>
 #include <rate_type.H>
+#include <temperature_table_rates.H>
+#include <reaclib_rates.H>
 
-using namespace Rates;
-using namespace Species;
+namespace modified_rates {
 
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_modified_rates(const tf_t& tfactors, T& rate_eval)
-{
-
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    using namespace temp_tabular;
 
 
+    template <int do_T_derivatives, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void
+    fill_rates(const tf_t& tfactors, T& rate_eval)
+    {
+
+        amrex::Real rate;
+        amrex::Real drate_dT;
+
+
+    }
 }
-
 #endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
@@ -1,5 +1,5 @@
-#ifndef REACLIB_RATES_H
-#define REACLIB_RATES_H
+#ifndef MODIFIED_RATES_H
+#define MODIFIED_RATES_H
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -11,18 +11,16 @@
 using namespace Rates;
 using namespace Species;
 
-<reaclib_rate_functions>(0)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_modified_rates(const tf_t& tfactors, T& rate_eval)
 {
 
     amrex::Real rate;
     amrex::Real drate_dT;
 
-    <fill_reaclib_rates>(1)
 
 }
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/modified_rates.H
@@ -18,11 +18,12 @@ namespace modified_rates {
     template <int do_T_derivatives, typename T>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void
-    fill_rates(const tf_t& tfactors, T& rate_eval)
+    fill_rates([[maybe_unused]] const tf_t& tfactors,
+               [[maybe_unused]] T& rate_eval)
     {
 
-        amrex::Real rate;
-        amrex::Real drate_dT;
+        [[maybe_unused]] amrex::Real rate;
+        [[maybe_unused]] amrex::Real drate_dT;
 
 
     }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/rate_type.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/rate_type.H
@@ -1,0 +1,25 @@
+#ifndef NET_RATE_TYPE_H
+#define NET_RATE_TYPE_H
+
+#include <actual_network.H>
+
+struct rate_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+#endif
+    amrex::Real enuc_weak;
+};
+
+struct rate_derivs_t {
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  screened_rates;
+    amrex::Array1D<amrex::Real, 1, Rates::NumRates>  dscreened_rates_dT;
+#ifdef SCREENING
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  log_screen;
+    amrex::Array1D<amrex::Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
+#endif
+    amrex::Real enuc_weak;
+};
+
+
+#endif

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
@@ -6,29 +6,10 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
+#include <rate_type.H>
 
 using namespace Rates;
 using namespace Species;
-
-struct rate_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-#endif
-    amrex::Real enuc_weak;
-};
-
-struct rate_derivs_t {
-    amrex::Array1D<amrex::Real, 1, NumRates>  screened_rates;
-    amrex::Array1D<amrex::Real, 1, NumRates>  dscreened_rates_dT;
-#ifdef SCREENING
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  log_screen;
-    amrex::Array1D<amrex::Real, 1, NumScreenPairs>  dlog_screen_dT;
-#endif
-    amrex::Real enuc_weak;
-};
-
-
 
 
 template <int do_T_derivatives, typename T>
@@ -39,21 +20,6 @@ fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 
     amrex::Real rate;
     amrex::Real drate_dT;
-
-
-}
-
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
-                  [[maybe_unused]] const amrex::Real rho,
-                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-                  [[maybe_unused]] T& rate_eval)
-{
-
-    [[maybe_unused]] amrex::Real rate{};
-    [[maybe_unused]] amrex::Real drate_dT{};
 
 
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
@@ -18,8 +18,8 @@ void
 fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 {
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    [[maybe_unused]] amrex::Real rate;
+    [[maybe_unused]] amrex::Real drate_dT;
 
 
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/reaclib_rates.H
@@ -15,7 +15,8 @@ using namespace Species;
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_reaclib_rates([[maybe_unused]] const tf_t& tfactors,
+                   [[maybe_unused]] T& rate_eval)
 {
 
     [[maybe_unused]] amrex::Real rate;

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/temperature_table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/temperature_table_rates.H
@@ -5,7 +5,7 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
-
+#include <interp_tools.H>
 
 using namespace amrex::literals;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/reaclib_rates.H
@@ -10,19 +10,19 @@ using namespace Rates;
 using namespace Species;
 
 struct rate_t {
-    Array1D<Real, 1, NumRates>  screened_rates;
+    Array1D<Real, 1, Rates::NumRates>  screened_rates;
 #ifdef SCREENING
-    Array1D<Real, 1, NumScreenPairs>  log_screen;
+    Array1D<Real, 1, Rates::NumScreenPairs>  log_screen;
 #endif
     Real enuc_weak;
 };
 
 struct rate_derivs_t {
-    Array1D<Real, 1, NumRates>  screened_rates;
-    Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Array1D<Real, 1, Rates::NumRates>  screened_rates;
+    Array1D<Real, 1, Rates::NumRates>  dscreened_rates_dT;
 #ifdef SCREENING
-    Array1D<Real, 1, NumScreenPairs>  log_screen;
-    Array1D<Real, 1, NumScreenPairs>  dlog_screen_dT;
+    Array1D<Real, 1, Rates::NumScreenPairs>  log_screen;
+    Array1D<Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
 #endif
     Real enuc_weak;
 };

--- a/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/reaclib_rates.H
+++ b/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/reaclib_rates.H
@@ -10,19 +10,19 @@ using namespace Rates;
 using namespace Species;
 
 struct rate_t {
-    Array1D<Real, 1, NumRates>  screened_rates;
+    Array1D<Real, 1, Rates::NumRates>  screened_rates;
 #ifdef SCREENING
-    Array1D<Real, 1, NumScreenPairs>  log_screen;
+    Array1D<Real, 1, Rates::NumScreenPairs>  log_screen;
 #endif
     Real enuc_weak;
 };
 
 struct rate_derivs_t {
-    Array1D<Real, 1, NumRates>  screened_rates;
-    Array1D<Real, 1, NumRates>  dscreened_rates_dT;
+    Array1D<Real, 1, Rates::NumRates>  screened_rates;
+    Array1D<Real, 1, Rates::NumRates>  dscreened_rates_dT;
 #ifdef SCREENING
-    Array1D<Real, 1, NumScreenPairs>  log_screen;
-    Array1D<Real, 1, NumScreenPairs>  dlog_screen_dT;
+    Array1D<Real, 1, Rates::NumScreenPairs>  log_screen;
+    Array1D<Real, 1, Rates::NumScreenPairs>  dlog_screen_dT;
 #endif
     Real enuc_weak;
 };

--- a/pynucastro/rates/modified_rate.py
+++ b/pynucastro/rates/modified_rate.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from pynucastro.rates.rate import Rate
 from pynucastro.rates.reaclib_rate import ReacLibRate
+from pynucastro.rates.starlib_rate import StarLibRate
+from pynucastro.rates.temperature_tabular_rate import TemperatureTabularRate
 
 
 class ModifiedRate(Rate):
@@ -49,12 +51,12 @@ class ModifiedRate(Rate):
         self.original_rate = original_rate
         self.update_screening = update_screening
 
-        # at the moment, this is only tested with ReacLibRate
-        # a potential issue is in the C++ code generation where
-        # we output modified rates only after ReacLib rates,
-        # so we need to make sure other rate types are computed
-        # first, before any modified rates
-        assert isinstance(original_rate, ReacLibRate)
+        # at the moment, this is only tested with ReacLibRate,
+        # TemperatureTabularRate, and StarLibRate rates.  It is
+        # important in the C++ code generation the we fill modified
+        # rates only after the original rate is filled.
+        assert isinstance(original_rate,
+                          (ReacLibRate, StarLibRate, TemperatureTabularRate))
 
         if new_reactants is not None:
             reactants = new_reactants

--- a/pynucastro/templates/amrexastro-cxx-microphysics/Make.package.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/Make.package.template
@@ -7,7 +7,10 @@ ifeq ($(USE_REACT),TRUE)
   CEXE_headers += interp_tools.H
   CEXE_headers += partition_functions.H
   CEXE_headers += actual_rhs.H
+  CEXE_headers += rate_type.H
   CEXE_headers += reaclib_rates.H
+  CEXE_headers += approximate_rates.H
+  CEXE_headers += modified_rates.H
   CEXE_headers += table_rates.H
   CEXE_headers += temperature_table_rates.H
   CEXE_headers += derived_rates.H

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -101,17 +101,20 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx
-    // rates and modified rates, since those may have ReacLibRate,
-    // TemperatureTabularRate, or DerivedRate as the underlying rate.
+    // fill modified rates next -- these can have ReacLib or
+    // TemperatureTabular/StarLib rates as the original rate
+    modified_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
+
+    // Calculate Derived Rates next. This should go last but before
+    // approx rates, since those may have ReacLibRate,
+    // TemperatureTabularRate / StarLibRate, or DerivedRate as the
+    // underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     <rate_param_tests>(1)
 
-    // Fill modified and approximate rates
-
-    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
+    // Fill approximate rates
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -1,5 +1,5 @@
-#ifndef actual_rhs_H
-#define actual_rhs_H
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -15,7 +15,10 @@
 #ifdef NEUTRINOS
 #include <neutrino.H>
 #endif
+#include <rate_type.H>
 #include <reaclib_rates.H>
+#include <approximate_rates.H>
+#include <modified_rates.H>
 #include <table_rates.H>
 #include <temperature_table_rates.H>
 #include <derived_rates.H>
@@ -98,17 +101,21 @@ void evaluate_rates(const burn_t& state,
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    // Calculate Derived Rates. This should go last but before approx rates.
+    // Calculate Derived Rates. This should go last but before approx
+    // rates and modified rates, since those may have ReacLibRate,
+    // TemperatureTabularRate, or DerivedRate as the underlying rate.
 
     fill_derived_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     <rate_param_tests>(1)
 
-    // Fill approximate rates
+    // Fill modified and approximate rates
+
+    fill_modified_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     fill_approx_rates<do_T_derivatives, T>(tfactors, state.rho, Y, rate_eval);
 
-    // Calculate tabular rates
+    // Calculate tabular weak rates
 
     [[maybe_unused]] amrex::Real rate, drate_dt, edot_nu, edot_gamma;
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/approximate_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/approximate_rates.H.template
@@ -1,0 +1,33 @@
+#ifndef APPROXIMATE_RATES_H
+#define APPROXIMATE_RATES_H
+
+#include <AMReX.H>
+#include <AMReX_Print.H>
+
+#include <tfactors.H>
+#include <actual_network.H>
+#include <rate_type.H>
+
+using namespace Rates;
+using namespace Species;
+
+<approx_rate_functions>(0)
+
+
+template <int do_T_derivatives, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+fill_approx_rates([[maybe_unused]] const tf_t& tfactors,
+                  [[maybe_unused]] const amrex::Real rho,
+                  [[maybe_unused]] const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
+                  [[maybe_unused]] T& rate_eval)
+{
+
+    [[maybe_unused]] amrex::Real rate{};
+    [[maybe_unused]] amrex::Real drate_dT{};
+
+    <fill_approx_rates>(1)
+
+}
+
+#endif

--- a/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
@@ -19,11 +19,12 @@ namespace modified_rates {
     template <int do_T_derivatives, typename T>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void
-    fill_rates(const tf_t& tfactors, T& rate_eval)
+    fill_rates([[maybe_unused]] const tf_t& tfactors,
+               [[maybe_unused]] T& rate_eval)
     {
 
-        amrex::Real rate;
-        amrex::Real drate_dT;
+        [[maybe_unused]] amrex::Real rate;
+        [[maybe_unused]] amrex::Real drate_dT;
 
         <fill_modified_rates>(2)
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
@@ -7,23 +7,26 @@
 #include <tfactors.H>
 #include <actual_network.H>
 #include <rate_type.H>
+#include <temperature_table_rates.H>
+#include <reaclib_rates.H>
 
-using namespace Rates;
-using namespace Species;
+namespace modified_rates {
 
-<modified_rate_functions>(0)
+    using namespace temp_tabular;
 
-template <int do_T_derivatives, typename T>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void
-fill_modified_rates(const tf_t& tfactors, T& rate_eval)
-{
+    <modified_rate_functions>(1)
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    template <int do_T_derivatives, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void
+    fill_rates(const tf_t& tfactors, T& rate_eval)
+    {
 
-    <fill_modified_rates>(1)
+        amrex::Real rate;
+        amrex::Real drate_dT;
 
+        <fill_modified_rates>(2)
+
+    }
 }
-
 #endif

--- a/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/modified_rates.H.template
@@ -1,5 +1,5 @@
-#ifndef REACLIB_RATES_H
-#define REACLIB_RATES_H
+#ifndef MODIFIED_RATES_H
+#define MODIFIED_RATES_H
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -11,18 +11,18 @@
 using namespace Rates;
 using namespace Species;
 
-<reaclib_rate_functions>(0)
+<modified_rate_functions>(0)
 
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_modified_rates(const tf_t& tfactors, T& rate_eval)
 {
 
     amrex::Real rate;
     amrex::Real drate_dT;
 
-    <fill_reaclib_rates>(1)
+    <fill_modified_rates>(1)
 
 }
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/rate_type.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/rate_type.H.template
@@ -1,0 +1,8 @@
+#ifndef NET_RATE_TYPE_H
+#define NET_RATE_TYPE_H
+
+#include <actual_network.H>
+
+<rate_struct>(0)
+
+#endif

--- a/pynucastro/templates/amrexastro-cxx-microphysics/reaclib_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/reaclib_rates.H.template
@@ -16,7 +16,8 @@ using namespace Species;
 template <int do_T_derivatives, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
-fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
+fill_reaclib_rates([[maybe_unused]] const tf_t& tfactors,
+                   [[maybe_unused]] T& rate_eval)
 {
 
     [[maybe_unused]] amrex::Real rate;

--- a/pynucastro/templates/amrexastro-cxx-microphysics/reaclib_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/reaclib_rates.H.template
@@ -19,8 +19,8 @@ void
 fill_reaclib_rates(const tf_t& tfactors, T& rate_eval)
 {
 
-    amrex::Real rate;
-    amrex::Real drate_dT;
+    [[maybe_unused]] amrex::Real rate;
+    [[maybe_unused]] amrex::Real drate_dT;
 
     <fill_reaclib_rates>(1)
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/temperature_table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/temperature_table_rates.H.template
@@ -5,7 +5,7 @@
 
 #include <tfactors.H>
 #include <actual_network.H>
-
+#include <interp_tools.H>
 
 using namespace amrex::literals;
 


### PR DESCRIPTION
each is now in its own header.  

This allows modified rates to use StarLib rates as the original rate now in C++.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
