### PR TITLE
PythonNetwork.plot_evolution: fix the color cycle again

### DIFF
--- a/pynucastro/networks/python_network.py
+++ b/pynucastro/networks/python_network.py
@@ -341,6 +341,9 @@ class NetworkSolution:
 
         """
 
+        if X_cutoff_value is None and ymin is not None:
+            X_cutoff_value = ymin
+
         # sort the nuclei by peak X, since that will ensure that the
         # color cycles don't put two very close species in the same
         # color
@@ -356,7 +359,11 @@ class NetworkSolution:
         c2 = 0
         c3 = 0
         styles = {}
-        for _, nuc, max_X in sorted_nuc:
+        for _, nuc, max_X in reversed(sorted_nuc):
+            if X_cutoff_value is not None:
+                if max_X < X_cutoff_value:
+                    continue
+
             if three_level_style:
                 # Set 3 levels of visual levels depending on maximum mass fraction
                 if max_X > 0.5:
@@ -387,8 +394,6 @@ class NetworkSolution:
             X = self.Y[i, :] * nuc.A
             max_X = X.max()
 
-            if X_cutoff_value is None and ymin is not None:
-                X_cutoff_value = ymin
             if X_cutoff_value is not None and max_X <= X_cutoff_value:
                 continue
 


### PR DESCRIPTION
we should reverse the sort so most abundant nuclei get the most distinct colors.  Also skip assigning colors to anything that is not plotted

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
