### PR TITLE
change how init="solar" works for Composition

### DIFF
--- a/pynucastro/nucdata/composition.py
+++ b/pynucastro/nucdata/composition.py
@@ -78,8 +78,14 @@ class Composition(collections.UserDict):
         a floor for nuclei mass fractions, used as the default value.
     init : str
         Different modes to set up the initial composition. Valid choices
-        are [`uniform`, `random`, `solar`]. If "solar" is selected, assume
-        we work with metallicity, Z=0.02. If init=None, then no initial composition
+        are:
+
+        * "lightest" : the least massive nucleus is given X = 1
+        * "random" : mass fractions are assigned randomly
+        * "solar" : uses the Lodders composition with Z=0.02
+        * "uniform" : all mass fractions are given the same value
+
+        If init=None, then no initial composition
         will be set.
     """
 
@@ -98,6 +104,9 @@ class Composition(collections.UserDict):
             _tmp_comp = solar.bin_as(nuclei)
             _tmp_comp.normalize()
             self.set_array(_tmp_comp.get_array())
+        elif init == "lightest":
+            lightest = min(nuc for nuc in self)
+            self.X[lightest] = 1.0
         elif init is None:
             pass
         else:

--- a/pynucastro/nucdata/composition.py
+++ b/pynucastro/nucdata/composition.py
@@ -107,6 +107,7 @@ class Composition(collections.UserDict):
         elif init == "lightest":
             lightest = min(nuc for nuc in self)
             self.X[lightest] = 1.0
+            self.normalize()
         elif init is None:
             pass
         else:

--- a/pynucastro/nucdata/composition.py
+++ b/pynucastro/nucdata/composition.py
@@ -94,7 +94,10 @@ class Composition(collections.UserDict):
         elif init == "random":
             self.set_random()
         elif init == "solar":
-            self.set_solar_like(Z=0.02)
+            solar = LoddersComposition(Z=0.02)
+            _tmp_comp = solar.bin_as(nuclei)
+            _tmp_comp.normalize()
+            self.set_array(_tmp_comp.get_array())
         elif init is None:
             pass
         else:


### PR DESCRIPTION
now it does an actual solar composition by binning the Lodders composition.
Previously it was "solar-like".  This change is more inline with expectations
and makes doing integration examples easy.

Also add init="lightest" which puts all the composition in the lightest nucleus

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
