### PR TITLE
AmrexAstroCxxNetwork: fix datatype for rate_pair_data

### DIFF
--- a/pynucastro/networks/amrexastro_cxx_network.py
+++ b/pynucastro/networks/amrexastro_cxx_network.py
@@ -200,7 +200,11 @@ class AmrexAstroCxxNetwork(BaseCxxNetwork):
         # Write RatePair data table
         nse_rate_pairs = self._get_nse_rate_pairs()
         NumNSERatePairs = len(nse_rate_pairs)
-        dtype = _signed_rate_dtype(NumNSERatePairs)
+
+        # the data type must accomodate the largest rate index, not
+        # just the number of rate pairs.  It also is signed because
+        # we use -1 to indicate no nucleus for < 3-body reactions.
+        dtype = _signed_rate_dtype(len(self.all_rates))
 
         # Write Fill in the rate indices
         of.write(f"{self.indent*n_indent}constexpr int NumNSERatePairs = {NumNSERatePairs};\n\n")

--- a/pynucastro/networks/amrexastro_cxx_network.py
+++ b/pynucastro/networks/amrexastro_cxx_network.py
@@ -201,7 +201,7 @@ class AmrexAstroCxxNetwork(BaseCxxNetwork):
         nse_rate_pairs = self._get_nse_rate_pairs()
         NumNSERatePairs = len(nse_rate_pairs)
 
-        # the data type must accomodate the largest rate index, not
+        # the data type must accommodate the largest rate index, not
         # just the number of rate pairs.  It also is signed because
         # we use -1 to indicate no nucleus for < 3-body reactions.
         dtype = _signed_rate_dtype(len(self.all_rates))


### PR DESCRIPTION
we hold the index of the rate, so the datatype must be able to accomodate the largest rate index, not just the number of NSE pairs.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
