### PR TITLE
fix Z_range/N_range for rotated=False plot

### DIFF
--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -2444,8 +2444,6 @@ class RateCollection:
             if ZA.min() == ZA.max():
                 ax.set_ylim(ZA.min() - 0.5, ZA.min() + 0.5)
 
-
-
         # add a legend showing the direction that each type of capture
         # moves you in the plane
 

--- a/pynucastro/networks/rate_collection.py
+++ b/pynucastro/networks/rate_collection.py
@@ -2429,6 +2429,10 @@ class RateCollection:
             if Z_range is not None and N_range is not None:
                 ax.set_xlim(N_range[0], N_range[1])
                 ax.set_ylim(Z_range[0], Z_range[1])
+                ax.set_aspect("equal")
+            else:
+                ax.set_aspect("equal", "datalim")
+
         else:
             if Z_range is not None:
                 ax.set_xlim(Z_range[0], Z_range[1])
@@ -2440,8 +2444,7 @@ class RateCollection:
             if ZA.min() == ZA.max():
                 ax.set_ylim(ZA.min() - 0.5, ZA.min() + 0.5)
 
-        if not rotated:
-            ax.set_aspect("equal", "datalim")
+
 
         # add a legend showing the direction that each type of capture
         # moves you in the plane


### PR DESCRIPTION
when we set both, we want the limits we set to take hold, so the ax should be "equal", but not "datalim"

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
