### PR TITLE
Remove reaclib duplicates

### DIFF
--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -513,7 +513,7 @@ class Library:
                 if len(match) == 2 and all([type(r) is ReacLibRate for r in match]):
                     rate_a, rate_b = match
 
-                    if len(rate_a.sets) == 1 and len(rate_b.sets) == 1:
+                    if all([len(r.sets) == 1 for r in match]):
                         info_a = rate_a.sets[0]
                         info_b = rate_b.sets[0]
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -509,6 +509,30 @@ class Library:
         for group in duplicates:
             for pref_type in rate_type_preference:
                 match = [r for r in group if types[pref_type](r)]
+
+                if len(match) == 2 and all([type(r) is ReacLibRate for r in match]):
+                    rate_a, rate_b = match
+
+                    if len(rate_a.sets) == 1 and len(rate_b.sets) == 1:
+                        info_a = rate_a.sets[0]
+                        info_b = rate_b.sets[0]
+
+                        # if two rates are both included in the recommended rates by ReacLib, 
+                        # I found that: 
+                        # (1) one was constant with respect to temperature, and originated 
+                        # from wc17
+                        # (2) and the other was derived from the inverse (marked by the 'v'
+                        # flag), originated from rath or ths8, and had a comment "unrecommended
+                        # via script" when viewed online at the ReacLib website. 
+                        # 
+                        # Knowing that (1) looks constant, I choose to keep (2). We identify 
+                        # (2) by .derived_from_inverse.
+
+                        if info_a.derived_from_inverse and not info_b.derived_from_inverse:
+                            match = [rate_a]
+                        elif info_b.derived_from_inverse and not info_a.derived_from_inverse:
+                            match = [rate_b]
+                
                 if match:
                     rates_to_remove.extend([r for r in group if r not in match])
                     break

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -510,10 +510,10 @@ class Library:
             for pref_type in rate_type_preference:
                 match = [r for r in group if types[pref_type](r)]
 
-                if len(match) == 2 and all([type(r) is ReacLibRate for r in match]):
+                if len(match) == 2 and all((isinstance(r, ReacLibRate) for r in match)):
                     rate_a, rate_b = match
 
-                    if all([len(r.sets) == 1 for r in match]):
+                    if all((len(r.sets) == 1 for r in match)):
                         info_a = rate_a.sets[0]
                         info_b = rate_b.sets[0]
 

--- a/pynucastro/rates/library.py
+++ b/pynucastro/rates/library.py
@@ -517,22 +517,22 @@ class Library:
                         info_a = rate_a.sets[0]
                         info_b = rate_b.sets[0]
 
-                        # if two rates are both included in the recommended rates by ReacLib, 
-                        # I found that: 
-                        # (1) one was constant with respect to temperature, and originated 
+                        # if two rates are both included in the recommended rates by ReacLib,
+                        # I found that:
+                        # (1) one was constant with respect to temperature, and originated
                         # from wc17
                         # (2) and the other was derived from the inverse (marked by the 'v'
                         # flag), originated from rath or ths8, and had a comment "unrecommended
-                        # via script" when viewed online at the ReacLib website. 
-                        # 
-                        # Knowing that (1) looks constant, I choose to keep (2). We identify 
+                        # via script" when viewed online at the ReacLib website.
+                        #
+                        # Knowing that (1) looks constant, I choose to keep (2). We identify
                         # (2) by .derived_from_inverse.
 
                         if info_a.derived_from_inverse and not info_b.derived_from_inverse:
                             match = [rate_a]
                         elif info_b.derived_from_inverse and not info_a.derived_from_inverse:
                             match = [rate_b]
-                
+
                 if match:
                     rates_to_remove.extend([r for r in group if r not in match])
                     break


### PR DESCRIPTION
## PR summary

This change extends `Library.eliminate_duplicate_rates()`, paring down duplicate pairs where both originate from ReacLib to a single chosen rate. The rate is chosen to be the one derived from the inverse rate in ReacLib.

## PR motivation

Some heavy nuclei in ReacLib have multiple recommended rates; this leads to errors when adding those nuclei to a network. See the discussion at [Issue 1096](https://github.com/pynucastro/pynucastro/issues/1096) for an exploration of what's going on. 

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
