### PR TITLE
fix extra navbar with pydata-sphinx-theme > 0.18

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,7 +173,8 @@ html_theme_options = {
         "text": f"pynucastro {version}",
         "image_light": "logo.png",
         "image_dark": "logo.png",
-    }
+    },
+    "navbar_persistent": []
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
sphinx-book-theme has been updated to 1.4.0 which pulls in pydata-sphinx-theme==0.20.0.  This now adds a second search field at the very top, spanning the entire width.  We need to explicitly disable this navbar now with sphinx-book-theme

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
