### PR TITLE
simplify screening pair check on ApproximateRate

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -15,7 +15,7 @@ from pynucastro.nucdata import Composition, Nucleus
 from pynucastro.numba_util import jitclass
 from pynucastro.rates.files import _find_rate_file
 from pynucastro.rates.known_duplicates import ALLOWED_DUPLICATES
-from pynucastro.screening import make_plasma_state, make_screen_factors
+from pynucastro.screening.screen import make_plasma_state, make_screen_factors
 
 
 class BaryonConservationError(Exception):

--- a/pynucastro/screening/screening_util.py
+++ b/pynucastro/screening/screening_util.py
@@ -1,5 +1,7 @@
 """Some helper functions for determining which rates need screening"""
 
+from pynucastro.rates.approximate_rates import ApproximateRate
+
 
 def get_screening_pair_set(rates):
     """Create a set of unique screening pairs for a list of rates.
@@ -15,13 +17,12 @@ def get_screening_pair_set(rates):
 
     """
 
-    # we need to consider the child rates that come with ApproximateRate
+    # we need to consider the child rates that come with
+    # ApproximateRate
     all_rates = []
     for r in rates:
         # check if rate is an ApproximateRate
-        # by checking if it has attribute approx_type
-        # Don't do isinstance(r, ApproximateRate) to avoid circular dependency
-        if hasattr(r, "approx_type"):
+        if isinstance(r, ApproximateRate):
             all_rates += r.get_child_rates()
         else:
             all_rates.append(r)


### PR DESCRIPTION
this removes the circular import
it is nice to be able to grep on ApproximateRate and find this

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
