### PR TITLE
move and rename create_double_neutron_capture

### DIFF
--- a/docs/source/double-n-capture.ipynb
+++ b/docs/source/double-n-capture.ipynb
@@ -180,7 +180,7 @@
    "id": "24fa469a-7365-4035-9695-ab7d9adf1069",
    "metadata": {},
    "source": [
-    "We can use the helper function `create_double_neutron_capture()` to create a pair (forward and reverse) of `ApproximateRates` that approximate out the intermediate nucleus:"
+    "We can use the helper function {py:meth}`make_double_neutron_rates <pynucastro.rates.aprox_family_rates.make_double_neutron_rates>` to create a pair (forward and reverse) of `ApproximateRates` that approximate out the intermediate nucleus:"
    ]
   },
   {
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rf, rr = pyna.rates.create_double_neutron_capture(rl, pyna.Nucleus(\"fe52\"), pyna.Nucleus(\"fe54\"))"
+    "rf, rr = pyna.rates.make_double_neutron_rates(rl, pyna.Nucleus(\"fe52\"), pyna.Nucleus(\"fe54\"))"
    ]
   },
   {
@@ -431,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/pynucastro/rates/__init__.py
+++ b/pynucastro/rates/__init__.py
@@ -2,8 +2,8 @@
 
 from pynucastro.nucdata import UnsupportedNucleus
 
-from .approximate_rates import ApproximateRate, create_double_neutron_capture
-from .aprox_family_rates import make_CO_approx_rates
+from .approximate_rates import ApproximateRate
+from .aprox_family_rates import make_CO_approx_rates, make_double_neutron_rates
 from .branched_rate import BranchedRate
 from .derived_rate import DerivedRate
 from .files import RateFileError, _find_rate_file

--- a/pynucastro/rates/approximate_rates.py
+++ b/pynucastro/rates/approximate_rates.py
@@ -13,6 +13,10 @@ from pynucastro.rates.rate import Rate
 def _assert_rate_prop(rate, *,
                       reactants=None, products=None,
                       num_reactants=None, num_products=None):
+    """Given a rate, check to make sure it has the desired reactants
+    and products.
+
+    """
 
     if reactants:
         for nuc in reactants:
@@ -25,47 +29,6 @@ def _assert_rate_prop(rate, *,
             assert nuc in rate.products
     if num_products:
         assert len(rate.products) == num_products
-
-
-def create_double_neutron_capture(lib, reactant, product):
-    """Return a pair of :py:class:`ApproximateRate` objects for the
-    A(n,g)X(n,g)B -> A(nn,g)B approximation
-
-    Parameters
-    ----------
-    lib : Library
-         A Library object containing the neutron-capture rates
-    reactant : Nucleus, str
-         The reactant, A, in the sequence A(n,g)X(n,g)B
-    product: Nucleus, str
-         The product, B, in the sequence A(n,g)X(n,g)B
-
-    Returns
-    -------
-    ApproximateRate, ApproximateRate
-
-    """
-
-    if isinstance(reactant, str):
-        reactant = Nucleus(reactant)
-
-    if isinstance(product, str):
-        product = Nucleus(product)
-
-    intermediate = reactant + Nucleus("n")
-
-    rates = {}
-    rates["A(n,g)X"] = lib.get_rate_by_name(f"{reactant.raw}(n,){intermediate.raw}")
-    rates["X(n,g)B"] = lib.get_rate_by_name(f"{intermediate.raw}(n,){product.raw}")
-
-    rates["B(g,n)X"] = lib.get_rate_by_name(f"{product.raw}(,n){intermediate.raw}")
-    rates["X(g,n)A"] = lib.get_rate_by_name(f"{intermediate.raw}(,n){reactant.raw}")
-
-    forward = ApproximateRate(rates, approx_type="nn_g")
-
-    reverse = ApproximateRate(rates, approx_type="nn_g", is_reverse=True)
-
-    return forward, reverse
 
 
 class ApproximateRate(Rate):

--- a/pynucastro/rates/aprox_family_rates.py
+++ b/pynucastro/rates/aprox_family_rates.py
@@ -9,8 +9,9 @@ from pynucastro.rates.library import _rate_name_to_nuc
 
 
 def make_double_neutron_rates(lib, reactant, product):
-    """Return a pair of :py:class:`ApproximateRate` objects for the
-    A(n,g)X(n,g)B -> A(nn,g)B approximation
+    """Return a pair of :py:class:`ApproximateRate
+    <pynucastro.rates.approximate_rates.ApproximateRate>` objects for
+    the A(n,g)X(n,g)B -> A(nn,g)B approximation
 
     Parameters
     ----------

--- a/pynucastro/rates/aprox_family_rates.py
+++ b/pynucastro/rates/aprox_family_rates.py
@@ -8,9 +8,51 @@ from pynucastro.rates.approximate_rates import ApproximateRate
 from pynucastro.rates.library import _rate_name_to_nuc
 
 
+def make_double_neutron_rates(lib, reactant, product):
+    """Return a pair of :py:class:`ApproximateRate` objects for the
+    A(n,g)X(n,g)B -> A(nn,g)B approximation
+
+    Parameters
+    ----------
+    lib : Library
+         A Library object containing the neutron-capture rates
+    reactant : Nucleus, str
+         The reactant, A, in the sequence A(n,g)X(n,g)B
+    product: Nucleus, str
+         The product, B, in the sequence A(n,g)X(n,g)B
+
+    Returns
+    -------
+    ApproximateRate, ApproximateRate
+
+    """
+
+    if isinstance(reactant, str):
+        reactant = Nucleus(reactant)
+
+    if isinstance(product, str):
+        product = Nucleus(product)
+
+    intermediate = reactant + Nucleus("n")
+
+    rates = {}
+    rates["A(n,g)X"] = lib.get_rate_by_name(f"{reactant.raw}(n,){intermediate.raw}")
+    rates["X(n,g)B"] = lib.get_rate_by_name(f"{intermediate.raw}(n,){product.raw}")
+
+    rates["B(g,n)X"] = lib.get_rate_by_name(f"{product.raw}(,n){intermediate.raw}")
+    rates["X(g,n)A"] = lib.get_rate_by_name(f"{intermediate.raw}(,n){reactant.raw}")
+
+    forward = ApproximateRate(rates, approx_type="nn_g")
+
+    reverse = ApproximateRate(rates, approx_type="nn_g", is_reverse=True)
+
+    return forward, reverse
+
+
 def make_CO_approx_rates(all_rates, root_nuclei,
                          return_obsolete_rate_names=False):
-    """We want to model a sequence like:
+    """Create approximate rates describing C/O burning.
+    We want to model a sequence like:
 
     ::
 

--- a/pynucastro/rates/tests/rate_tests/test_approx_rate.py
+++ b/pynucastro/rates/tests/rate_tests/test_approx_rate.py
@@ -4,7 +4,7 @@ import pytest
 from pytest import approx
 
 import pynucastro as pyna
-from pynucastro.rates import create_double_neutron_capture
+from pynucastro.rates import make_double_neutron_rates
 
 
 class TestAlphaGammaTfactors:
@@ -67,7 +67,7 @@ class TestDoubleN:
     @pytest.fixture(scope="class")
     @classmethod
     def nn(cls, reaclib_library):
-        return create_double_neutron_capture(reaclib_library, "Fe52", "Fe54")
+        return make_double_neutron_rates(reaclib_library, "Fe52", "Fe54")
 
     def test_nn_name(self, nn):
         """ this is run before each test """


### PR DESCRIPTION
it is now in aprox_family_rates, together with make_CO_aprox_rates I will add more helper functions here shortly and standardize their interfaces.  The new name matches the style of make_CO_aprox_rates

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the flake8 and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
