### PR TITLE
allow ModifiedRate to set rate_source

### DIFF
--- a/pynucastro/rates/modified_rate.py
+++ b/pynucastro/rates/modified_rate.py
@@ -40,13 +40,18 @@ class ModifiedRate(Rate):
         do we reset the screening pairs for this rate to reflect any
         new products or stoichiometry? or do we still screen based on
         the underlying rate?
+    rate_source: str
+        the key to get the source information for the rate
+        from rate_sources.csv.  This information is also used in the
+        unique ``Rate.id``
 
     """
 
     def __init__(self, original_rate, *,
                  stoichiometry=None,
                  new_reactants=None, new_products=None,
-                 update_screening=False):
+                 update_screening=False,
+                 rate_source=None):
 
         self.original_rate = original_rate
         self.update_screening = update_screening
@@ -71,9 +76,8 @@ class ModifiedRate(Rate):
         super().__init__(reactants=reactants, products=products,
                          weak_type=self.original_rate.weak_type,
                          label="modified",
-                         stoichiometry=stoichiometry)
-
-        self.modified = True
+                         stoichiometry=stoichiometry,
+                         rate_source=rate_source)
 
         self._set_print_representation()
 

--- a/pynucastro/rates/tests/rate_tests/test_modified_rate_source.py
+++ b/pynucastro/rates/tests/rate_tests/test_modified_rate_source.py
@@ -1,0 +1,52 @@
+# test the `rate_source=` keyword argument to `ModifiedRate`
+
+import pytest
+
+import pynucastro as pyna
+
+
+class TestModifiedRateSource:
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def pprates(cls, reaclib_library):
+        return reaclib_library.get_rate_by_name("p(p,)d")
+
+    def test_without_source(self, pprates):
+
+        rpp, rpep = pprates
+
+        rppp_he3 = pyna.ModifiedRate(rpp,
+                             new_products=[pyna.Nucleus("he3")],
+                             stoichiometry={pyna.Nucleus("p"): 3})
+
+        rpepp_he3 = pyna.ModifiedRate(rpep,
+                              new_products=[pyna.Nucleus("he3")],
+                              stoichiometry={pyna.Nucleus("p"): 3})
+
+        # these two rates have the same id, so an error will be raised
+        with pytest.raises(ValueError,
+                           match="supplied a Rate object already in the Library: 3 p --> He3 <modified>"):
+            _ = pyna.Library(rates=[rppp_he3, rpepp_he3])
+        
+    def test_with_source(self, pprates):
+
+        rpp, rpep = pprates
+
+        rppp_he3 = pyna.ModifiedRate(rpp,
+                             new_products=[pyna.Nucleus("he3")],
+                             stoichiometry={pyna.Nucleus("p"): 3},
+                             rate_source=rpp.src)
+
+        assert rppp_he3.id == "3 p --> He3 <modified_bet+>"
+
+        rpepp_he3 = pyna.ModifiedRate(rpep,
+                              new_products=[pyna.Nucleus("he3")],
+                              stoichiometry={pyna.Nucleus("p"): 3},
+                              rate_source=rpep.src)
+
+        assert rpepp_he3.id == "3 p --> He3 <modified_ec>"
+
+        lib = pyna.Library(rates=[rppp_he3, rpepp_he3])
+
+        assert len(lib.get_rates()) == 2

--- a/pynucastro/rates/tests/rate_tests/test_modified_rate_source.py
+++ b/pynucastro/rates/tests/rate_tests/test_modified_rate_source.py
@@ -28,7 +28,7 @@ class TestModifiedRateSource:
         with pytest.raises(ValueError,
                            match="supplied a Rate object already in the Library: 3 p --> He3 <modified>"):
             _ = pyna.Library(rates=[rppp_he3, rpepp_he3])
-        
+
     def test_with_source(self, pprates):
 
         rpp, rpep = pprates


### PR DESCRIPTION
this will be needed to distiguish beta+ and ec rates that otherwise would have the same Rate.id.  The supplied unit test exercises this case

Also finish removing .modified.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the ruff and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
