### PR TITLE
also compare weak_type for Rate.__eq__

### DIFF
--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -350,7 +350,9 @@ class Rate:
 
         """
 
-        return (self.reactants, self.products) == (other.reactants, other.products)
+        test1 = self.weak_type == other.weak_type
+        test2 = (self.reactants, self.products) == (other.reactants, other.products)
+        return test1 and test2
 
     def __lt__(self, other):
         """Sort such that lightest reactants come first, and then look


### PR DESCRIPTION
when we create ModifedRate that are weak, if we have two that have the same reactants and products, but are different weak types, we need them distinguishable.  Otherwise, they both are not put into RateCollection.modified_rates

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the ruff and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
