### PR TITLE
some optimizations to C++ tabular rate interpolation

### DIFF
--- a/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
+++ b/.github/workflows/microphysics-benchmarks/ecsn_unit_test.out
@@ -1,5 +1,5 @@
-Initializing AMReX (26.01-40-gbac24575699e)...
-AMReX (26.01-40-gbac24575699e) initialized
+Initializing AMReX (26.09-11-gae079342654b)...
+AMReX (26.09-11-gae079342654b) initialized
 starting the single zone burn...
 Maximum Time (s): 0.01
 State Density (g/cm^3): 100000000
@@ -29,32 +29,32 @@ RHS at t = 0
    S32 1323519.174
 ------------------------------------
 successful? 1
- - Hnuc = 4.397923975e+19
- - added e = 4.397923975e+17
- - final T = 6656299012
+ - Hnuc = 4.397923993e+19
+ - added e = 4.397923993e+17
+ - final T = 6656299021
 ------------------------------------
 e initial = 5.995956082e+17
-e final =   1.039388006e+18
+e final =   1.039388008e+18
 ------------------------------------
 new mass fractions: 
 H1 0.00930704898
-He4 3.598626434e-13
-O16 6.943251473e-07
+He4 3.598624891e-13
+O16 6.943241327e-07
 O20 0.009997687151
 F20 0.009996314385
-Ne20 1.027875355e-13
+Ne20 1.02787534e-13
 Mg24 1.168433215e-06
-Al27 1.542488749e-18
+Al27 1.54248815e-18
 Si28 0.326205294
-P31 8.174124805e-14
+P31 8.174121329e-14
 S32 0.6444917927
 ------------------------------------
 species creation rates: 
-omegadot(H1): -0.06929510197
+omegadot(H1): -0.06929510196
 omegadot(He4): -3
 omegadot(O16): -49.99993057
-omegadot(O20): -0.0002312849373
-omegadot(F20): -0.000368561525
+omegadot(O20): -0.0002312849381
+omegadot(F20): -0.0003685615293
 omegadot(Ne20): -30
 omegadot(Mg24): -9.999883157
 omegadot(Al27): -1
@@ -62,4 +62,4 @@ omegadot(Si28): 31.6205294
 omegadot(P31): -1
 omegadot(S32): 63.44917927
 number of steps taken: 635
-AMReX (26.01-40-gbac24575699e) finalized
+AMReX (26.09-11-gae079342654b) finalized

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -393,8 +393,8 @@ class BaseCxxNetwork(ABC, RateCollection):
 
             for r in self.tabular_rates:
 
-                of.write(f'{idnt}tabular_evaluate({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data,\n')
-                of.write(f'{idnt}                 log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);\n')
+                of.write(f'{idnt}tabular_evaluate<do_T_derivatives>({r.table_index_name}_meta, {r.table_index_name}_rhoy, {r.table_index_name}_temp, {r.table_index_name}_data,\n')
+                of.write(f'{idnt}                                    log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);\n')
 
                 of.write(f'{idnt}rate_eval.screened_rates(k_{r.fname}) = rate;\n')
 

--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -580,7 +580,7 @@ class BaseCxxNetwork(ABC, RateCollection):
                              namespace="branched_rates")
 
         # Now do tabular weak rates explicitly
-        of.write(f"{self.indent*n_indent}tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);\n")
+        of.write(f"{self.indent*n_indent}tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);\n")
         of.write('\n')
 
         # Compose and write ydot for all weak reactions

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -137,7 +137,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/actual_rhs.H
@@ -210,7 +210,7 @@ void get_ydot_weak(const burn_t& state,
 
     // Compute all weak rates and get ydot_weak
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
 
     ydot_nuc(He4) = 0.0_rt;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/table_rates.H
@@ -78,26 +78,15 @@ evaluate_linear_2d(const amrex::Real fip1jp1, const amrex::Real fip1j, const amr
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    amrex::Real f;
-    amrex::Real dx = xhi - xlo;
-    amrex::Real dxinv = 1.0_rt / dx;
-    amrex::Real dy = yhi - ylo;
-    amrex::Real dyinv = 1.0_rt / dy;
+    const amrex::Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const amrex::Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    amrex::Real E =  fij;
-    amrex::Real C = (fijp1 - fij) * dyinv;
-    amrex::Real B = (fip1j - fij) * dxinv;
-    amrex::Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const amrex::Real E = fij;
+    const amrex::Real C = fijp1 - fij;
+    const amrex::Real B = fip1j - fij;
+    const amrex::Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    amrex::Real xx = amrex::Clamp(x, xlo, xhi);
-    amrex::Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -274,7 +263,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -296,13 +285,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
@@ -320,15 +311,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = amrex::Math::exp10(entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
     edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_approx_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     AMREX_GPU_DEVICE AMREX_INLINE
     void
     fill_rates([[maybe_unused]] const amrex::Real temp,

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -190,7 +190,7 @@ void get_ydot_weak(const burn_t& state,
 
     // Compute all weak rates and get ydot_weak
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
 
     ydot_nuc(H1) = 0.0_rt;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/actual_rhs.H
@@ -117,7 +117,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/table_rates.H
@@ -78,26 +78,15 @@ evaluate_linear_2d(const amrex::Real fip1jp1, const amrex::Real fip1j, const amr
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    amrex::Real f;
-    amrex::Real dx = xhi - xlo;
-    amrex::Real dxinv = 1.0_rt / dx;
-    amrex::Real dy = yhi - ylo;
-    amrex::Real dyinv = 1.0_rt / dy;
+    const amrex::Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const amrex::Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    amrex::Real E =  fij;
-    amrex::Real C = (fijp1 - fij) * dyinv;
-    amrex::Real B = (fip1j - fij) * dxinv;
-    amrex::Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const amrex::Real E = fij;
+    const amrex::Real C = fijp1 - fij;
+    const amrex::Real B = fip1j - fij;
+    const amrex::Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    amrex::Real xx = amrex::Clamp(x, xlo, xhi);
-    amrex::Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -274,7 +263,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -296,13 +285,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
@@ -320,15 +311,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = amrex::Math::exp10(entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
     edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_derived_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     AMREX_GPU_DEVICE AMREX_INLINE
     void
     fill_rates([[maybe_unused]] const amrex::Real temp,

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -117,7 +117,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/actual_rhs.H
@@ -201,7 +201,7 @@ void get_ydot_weak(const burn_t& state,
         rate_eval.screened_rates(k_n_to_p_beta_neg_reaclib) = rate;
     }
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
 
     const auto& screened_rates = rate_eval.screened_rates;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/table_rates.H
@@ -1008,26 +1008,15 @@ evaluate_linear_2d(const amrex::Real fip1jp1, const amrex::Real fip1j, const amr
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    amrex::Real f;
-    amrex::Real dx = xhi - xlo;
-    amrex::Real dxinv = 1.0_rt / dx;
-    amrex::Real dy = yhi - ylo;
-    amrex::Real dyinv = 1.0_rt / dy;
+    const amrex::Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const amrex::Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    amrex::Real E =  fij;
-    amrex::Real C = (fijp1 - fij) * dyinv;
-    amrex::Real B = (fip1j - fij) * dxinv;
-    amrex::Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const amrex::Real E = fij;
+    const amrex::Real C = fijp1 - fij;
+    const amrex::Real B = fip1j - fij;
+    const amrex::Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    amrex::Real xx = amrex::Clamp(x, xlo, xhi);
-    amrex::Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -1204,7 +1193,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -1226,13 +1215,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
@@ -1250,15 +1241,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = amrex::Math::exp10(entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
     edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     AMREX_GPU_DEVICE AMREX_INLINE
     void
     fill_rates([[maybe_unused]] const amrex::Real temp,
@@ -30,16 +30,16 @@ namespace tabular_weak_rates {
         const amrex::Real log_temp = std::log10(temp);
         const amrex::Real log_rhoy = std::log10(rhoy);
 
-        tabular_evaluate(j_Na23_Ne23_meta, j_Na23_Ne23_rhoy, j_Na23_Ne23_temp, j_Na23_Ne23_data,
-                         log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);
+        tabular_evaluate<do_T_derivatives>(j_Na23_Ne23_meta, j_Na23_Ne23_rhoy, j_Na23_Ne23_temp, j_Na23_Ne23_data,
+                                            log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);
         rate_eval.screened_rates(k_Na23_to_Ne23_electron_capture_weaktab) = rate;
         if constexpr (std::is_same_v<T, rate_derivs_t>) {
             rate_eval.dscreened_rates_dT(k_Na23_to_Ne23_electron_capture_weaktab) = drate_dt;
         }
         rate_eval.enuc_weak += C::n_A * Y(Na23) * (edot_nu + edot_gamma);
 
-        tabular_evaluate(j_Ne23_Na23_meta, j_Ne23_Na23_rhoy, j_Ne23_Na23_temp, j_Ne23_Na23_data,
-                         log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);
+        tabular_evaluate<do_T_derivatives>(j_Ne23_Na23_meta, j_Ne23_Na23_rhoy, j_Ne23_Na23_temp, j_Ne23_Na23_data,
+                                            log_rhoy, log_temp, temp, rate, drate_dt, edot_nu, edot_gamma);
         rate_eval.screened_rates(k_Ne23_to_Na23_beta_neg_weaktab) = rate;
         if constexpr (std::is_same_v<T, rate_derivs_t>) {
             rate_eval.dscreened_rates_dT(k_Ne23_to_Na23_beta_neg_weaktab) = drate_dt;

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
@@ -180,7 +180,7 @@ void get_ydot_weak(const burn_t& state,
 
     // Compute all weak rates and get ydot_weak
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
 
     ydot_nuc(H1) = 0.0_rt;
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/actual_rhs.H
@@ -107,7 +107,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/table_rates.H
@@ -78,26 +78,15 @@ evaluate_linear_2d(const amrex::Real fip1jp1, const amrex::Real fip1j, const amr
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    amrex::Real f;
-    amrex::Real dx = xhi - xlo;
-    amrex::Real dxinv = 1.0_rt / dx;
-    amrex::Real dy = yhi - ylo;
-    amrex::Real dyinv = 1.0_rt / dy;
+    const amrex::Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const amrex::Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    amrex::Real E =  fij;
-    amrex::Real C = (fijp1 - fij) * dyinv;
-    amrex::Real B = (fip1j - fij) * dxinv;
-    amrex::Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const amrex::Real E = fij;
+    const amrex::Real C = fijp1 - fij;
+    const amrex::Real B = fip1j - fij;
+    const amrex::Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    amrex::Real xx = amrex::Clamp(x, xlo, xhi);
-    amrex::Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -274,7 +263,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -296,13 +285,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
@@ -320,15 +311,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = amrex::Math::exp10(entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
     edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_amrexastro_cxx_temptab_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     AMREX_GPU_DEVICE AMREX_INLINE
     void
     fill_rates([[maybe_unused]] const amrex::Real temp,

--- a/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/actual_rhs.H
@@ -110,7 +110,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     // Calculate tabular rates
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     // fill modified rates next -- these can have ReacLib or
     // TemperatureTabular/StarLib rates as the original rate

--- a/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/table_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/table_rates.H
@@ -76,26 +76,15 @@ evaluate_linear_2d(const Real fip1jp1, const Real fip1j, const Real fijp1, const
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    Real f;
-    Real dx = xhi - xlo;
-    Real dxinv = 1.0_rt / dx;
-    Real dy = yhi - ylo;
-    Real dyinv = 1.0_rt / dy;
+    const Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    Real E =  fij;
-    Real C = (fijp1 - fij) * dyinv;
-    Real B = (fip1j - fij) * dxinv;
-    Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const Real E = fij;
+    const Real C = fijp1 - fij;
+    const Real B = fip1j - fij;
+    const Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    Real xx = amrex::Clamp(x, xlo, xhi);
-    Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -272,7 +261,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -294,13 +283,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 tabular_evaluate(const table_t& table_meta,
@@ -318,15 +309,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = std::pow(10.0_rt, entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
     edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/cxx_net_tests/_simple_cxx_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     inline
     void
     fill_rates([[maybe_unused]] const Real temp,

--- a/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/actual_rhs.H
+++ b/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/actual_rhs.H
@@ -110,7 +110,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     // Calculate tabular rates
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     // fill modified rates next -- these can have ReacLib or
     // TemperatureTabular/StarLib rates as the original rate

--- a/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/table_rates.H
+++ b/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/table_rates.H
@@ -76,26 +76,15 @@ evaluate_linear_2d(const Real fip1jp1, const Real fip1j, const Real fijp1, const
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    Real f;
-    Real dx = xhi - xlo;
-    Real dxinv = 1.0_rt / dx;
-    Real dy = yhi - ylo;
-    Real dyinv = 1.0_rt / dy;
+    const Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    Real E =  fij;
-    Real C = (fijp1 - fij) * dyinv;
-    Real B = (fip1j - fij) * dxinv;
-    Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const Real E = fij;
+    const Real C = fijp1 - fij;
+    const Real B = fip1j - fij;
+    const Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    Real xx = amrex::Clamp(x, xlo, xhi);
-    Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -272,7 +261,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -294,13 +283,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 tabular_evaluate(const table_t& table_meta,
@@ -318,15 +309,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = std::pow(10.0_rt, entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
     edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
 }

--- a/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/tabular_weak_rates.H
+++ b/pynucastro/networks/tests/fortran_net_tests/_fortran_reference/tabular_weak_rates.H
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     inline
     void
     fill_rates([[maybe_unused]] const Real temp,

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -98,7 +98,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/actual_rhs.H.template
@@ -98,7 +98,7 @@ void evaluate_rates(const burn_t& state,
 
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
-    tabular_weak_rates::fill_rates<do_T_derivatives>(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     temp_tabular::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 

--- a/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/table_rates.H.template
@@ -79,26 +79,15 @@ evaluate_linear_2d(const amrex::Real fip1jp1, const amrex::Real fip1j, const amr
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    amrex::Real f;
-    amrex::Real dx = xhi - xlo;
-    amrex::Real dxinv = 1.0_rt / dx;
-    amrex::Real dy = yhi - ylo;
-    amrex::Real dyinv = 1.0_rt / dy;
+    const amrex::Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const amrex::Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    amrex::Real E =  fij;
-    amrex::Real C = (fijp1 - fij) * dyinv;
-    amrex::Real B = (fip1j - fij) * dxinv;
-    amrex::Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const amrex::Real E = fij;
+    const amrex::Real C = fijp1 - fij;
+    const amrex::Real B = fip1j - fij;
+    const amrex::Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    amrex::Real xx = amrex::Clamp(x, xlo, xhi);
-    amrex::Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -275,7 +264,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -297,13 +286,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 AMREX_INLINE AMREX_GPU_DEVICE
 void
 tabular_evaluate(const table_t& table_meta,
@@ -321,15 +312,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = amrex::Math::exp10(entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -amrex::Math::exp10(entries(jtab_nuloss));
     edot_gamma = amrex::Math::exp10(entries(jtab_gamma));
 }

--- a/pynucastro/templates/amrexastro-cxx-microphysics/tabular_weak_rates.H.template
+++ b/pynucastro/templates/amrexastro-cxx-microphysics/tabular_weak_rates.H.template
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     AMREX_GPU_DEVICE AMREX_INLINE
     void
     fill_rates([[maybe_unused]] const amrex::Real temp,

--- a/pynucastro/templates/simple-cxx-network/actual_rhs.H.template
+++ b/pynucastro/templates/simple-cxx-network/actual_rhs.H.template
@@ -87,7 +87,7 @@ void evaluate_rates(const burn_t& state, T& rate_eval) {
     reaclib_rates::fill_rates<do_T_derivatives, T>(tfactors, rate_eval);
 
     // Calculate tabular rates
-    tabular_weak_rates::fill_rates(state.T, rhoy, Y, rate_eval);
+    tabular_weak_rates::fill_rates<do_T_derivatives, T>(state.T, rhoy, Y, rate_eval);
 
     // fill modified rates next -- these can have ReacLib or
     // TemperatureTabular/StarLib rates as the original rate

--- a/pynucastro/templates/simple-cxx-network/table_rates.H.template
+++ b/pynucastro/templates/simple-cxx-network/table_rates.H.template
@@ -77,26 +77,15 @@ evaluate_linear_2d(const Real fip1jp1, const Real fip1j, const Real fijp1, const
 {
     // This is the 2-D linear interpolator, as an extension of evaluate_linear_1d.
 
-    Real f;
-    Real dx = xhi - xlo;
-    Real dxinv = 1.0_rt / dx;
-    Real dy = yhi - ylo;
-    Real dyinv = 1.0_rt / dy;
+    const Real u = (amrex::Clamp(x, xlo, xhi) - xlo) / (xhi - xlo);
+    const Real v = (amrex::Clamp(y, ylo, yhi) - ylo) / (yhi - ylo);
 
-    Real E =  fij;
-    Real C = (fijp1 - fij) * dyinv;
-    Real B = (fip1j - fij) * dxinv;
-    Real A = (fip1jp1 - B * dx - C * dy - E) * (dxinv * dyinv);
+    const Real E = fij;
+    const Real C = fijp1 - fij;
+    const Real B = fip1j - fij;
+    const Real A = fip1jp1 - fip1j - fijp1 + fij;
 
-    Real xx = amrex::Clamp(x, xlo, xhi);
-    Real yy = amrex::Clamp(y, ylo, yhi);
-
-    f =  A * (xx - xlo) * (yy - ylo) +
-         B * (xx - xlo) +
-         C * (yy - ylo) +
-         E;
-
-    return f;
+    return A * u * v + B * u + C * v + E;
 }
 
 
@@ -273,7 +262,7 @@ evaluate_dr_dtemp(const int irhoy_lo, const int jtemp_lo,
 }
 
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 get_entries(const int irhoy_lo, const int jtemp_lo,
@@ -295,13 +284,15 @@ get_entries(const int irhoy_lo, const int jtemp_lo,
                                         log_rhoy_table, log_temp_table, data,
                                         log_rhoy, log_temp, jtab_gamma);
 
-    entries(k_index_dlogr_dlogt) =
-        evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
-                          table_meta, log_rhoy_table, log_temp_table, data,
-                          log_rhoy, log_temp);
+    if constexpr (do_T_derivatives) {
+        entries(k_index_dlogr_dlogt) =
+            evaluate_dr_dtemp(irhoy_lo, jtemp_lo,
+                              table_meta, log_rhoy_table, log_temp_table, data,
+                              log_rhoy, log_temp);
+    }
 }
 
-template <typename R, typename T, typename D>
+template <int do_T_derivatives, typename R, typename T, typename D>
 inline
 void
 tabular_evaluate(const table_t& table_meta,
@@ -319,15 +310,19 @@ tabular_evaluate(const table_t& table_meta,
     const int irhoy_lo = interp_net::find_index_extrap(log_rhoy, log_rhoy_table);
     const int jtemp_lo = interp_net::find_index_extrap(log_temp, log_temp_table);
 
-    get_entries(irhoy_lo, jtemp_lo,
-                table_meta, log_rhoy_table, log_temp_table, data,
-                log_rhoy, log_temp, entries);
+    get_entries<do_T_derivatives>(irhoy_lo, jtemp_lo,
+                                  table_meta, log_rhoy_table, log_temp_table, data,
+                                  log_rhoy, log_temp, entries);
 
     // Fill outputs: rate, d(rate)/d(temperature), and
     // (negative) neutrino loss contribution to energy generation
 
     rate       = std::pow(10.0_rt, entries(jtab_rate));
-    drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    if constexpr (do_T_derivatives) {
+        drate_dt   = rate * entries(k_index_dlogr_dlogt) / temp;
+    } else {
+        drate_dt = 0.0;
+    }
     edot_nu    = -std::pow(10.0_rt, entries(jtab_nuloss));
     edot_gamma = std::pow(10.0_rt, entries(jtab_gamma));
 }

--- a/pynucastro/templates/simple-cxx-network/tabular_weak_rates.H.template
+++ b/pynucastro/templates/simple-cxx-network/tabular_weak_rates.H.template
@@ -12,7 +12,7 @@ namespace tabular_weak_rates {
 
     using namespace rate_tables;
 
-    template <typename T>
+    template <int do_T_derivatives, typename T>
     inline
     void
     fill_rates([[maybe_unused]] const Real temp,


### PR DESCRIPTION
this does an algebraically equivalent simplication to the 2d interp also don't interpolate the T derivative unless we need derivatives

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the ruff and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
