### PR TITLE
fix the size of the int used in starlib random numbers

### DIFF
--- a/pynucastro/networks/base_cxx_network.py
+++ b/pynucastro/networks/base_cxx_network.py
@@ -915,7 +915,7 @@ class BaseCxxNetwork(ABC, RateCollection):
 
 namespace starlib {{
 
-    constexpr std::uint8_t NumStarLibRates = {num_sl};
+    constexpr {_rate_dtype(len(self.starlib_rates))} NumStarLibRates = {num_sl};
     inline {self.gpu_managed_specifier} {self.array_namespace}Array1D<{self.dtype}, 1, NumStarLibRates> prand{{}};
 }}"""
 
@@ -945,7 +945,7 @@ namespace starlib {{
 
     def _fill_starlib_func(self, n_indent, of):
 
-        header = [f"template<{_rate_dtype(len(self.starlib_rates))} rate>",
+        header = [f"template<{_rate_dtype(len(self.all_rates))} rate>",
                   f"{self.function_specifier}",
                   f"constexpr {self.dtype} get_p_random() {{"]
 


### PR DESCRIPTION
in C++ nets, get_p_rand() needs to work on a rate index that is up to the total number of rates, since StarLib rates can be anywhere in the list.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the main branch
    * Pass the ruff and pylint checkers -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] this PR will change answers in tests to more than roundoff level
- [ ] all newly-added functions have docstrings
- [ ] if appropriate, this change is described in the docs
- [ ] generative AI was used in producing the code
